### PR TITLE
Update travis CI to run coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ android:
   licenses:
     - android-sdk-license-.+
 script:
-  - "./gradlew assemble testCoverage"
+  - "./gradlew assemble testCoverage publishToMavenLocal"
   - "./gradlew -b sample/build.gradle build"
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,10 @@ android:
   licenses:
     - android-sdk-license-.+
 script:
-  - "./gradlew build"
+  - "./gradlew assemble testCoverage"
   - "./gradlew -b sample/build.gradle build"
+after_success:
+  - bash <(curl -s https://codecov.io/bash)
 before_install:
   - yes | sdkmanager "platforms;android-29"
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ android:
   licenses:
     - android-sdk-license-.+
 script:
-  - "./gradlew assemble"
+  - "./gradlew build"
+  - "./gradlew -b sample/build.gradle build"
 before_install:
   - yes | sdkmanager "platforms;android-29"
 branches:

--- a/affectedmoduledetector/build.gradle
+++ b/affectedmoduledetector/build.gradle
@@ -6,6 +6,9 @@ plugins {
     id "com.gradle.plugin-publish" version "0.12.0"
 }
 
+
+apply from: rootProject.file("gradle/jacoco.gradle")
+
 java {
     sourceCompatibility = JavaVersion.VERSION_1_7
     targetCompatibility = JavaVersion.VERSION_1_7

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.3.72"
+    ext.kotlin_version = "1.4.10"
     repositories {
         google()
         jcenter()

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,3 @@
-
-
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext.kotlin_version = "1.3.72"
@@ -14,6 +12,7 @@ buildscript {
         classpath "com.android.tools.build:gradle:4.1.0"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath("org.jlleitschuh.gradle:ktlint-gradle:9.1.1")
+        classpath("org.jacoco:org.jacoco.core:0.8.5")
     }
 }
 

--- a/gradle/jacoco.gradle
+++ b/gradle/jacoco.gradle
@@ -1,0 +1,57 @@
+// Merge of
+// https://github.com/mgouline/android-samples/blob/master/jacoco/app/build.gradle
+// and https://github.com/pushtorefresh/storio/blob/master/gradle/jacoco-android.gradle
+
+// Enables code coverage for JVM tests.
+apply plugin: "jacoco"
+// Android Gradle Plugin out of the box supports only code coverage for instrumentation tests.
+// Creates a task that will merge coverage for all projects
+project.afterEvaluate {
+    def testTaskName = "test"
+    def coverageTaskName = "${testTaskName}Coverage"
+
+    // Create coverage task of form 'testFlavorTypeUnitTestCoverage' depending on 'testFlavorTypeUnitTest'
+    task "${coverageTaskName}"(type: JacocoReport, dependsOn: "$testTaskName") {
+        group = 'Reporting'
+        description = "Generate Jacoco coverage reports for the build."
+
+        List<String> fileFilter = ['**/R.class',
+                                   '**/R$*.class',
+                                   '**/*$ViewInjector*.*',
+                                   '**/*$ViewBinder*.*',
+                                   '**/BuildConfig.*',
+                                   '**/Manifest*.*',
+                                   '**/*$Lambda$*.*', // Jacoco can not handle several "$" in class name.
+                                   '**/*$inlined$*.*', // Kotlin specific, Jacoco can not handle several "$" in class name.
+                                   '**/*Module.*', // Modules for Dagger.
+                                   '**/*Dagger*.*', // Dagger auto-generated code.
+                                   '**/*MembersInjector*.*', // Dagger auto-generated code.
+                                   '**/*_Provide*Factory*.*', // Dagger auto-generated code.
+                                   '**/test/**/*.*', // Test code
+        ]
+        def kotlinFileTree = fileTree(
+                dir: "${project.buildDir}/classes",
+                excludes: fileFilter)
+        logger.debug("Kotlin classes dirs: " + kotlinFileTree)
+
+        classDirectories.setFrom kotlinFileTree
+
+        def coverageSourceDirs = new File(project.projectDir, "src/main/java")
+        def coverageData = fileTree(dir: new File(project.buildDir, 'jacoco'), include: '*.exec')
+
+        logger.debug("Coverage source dirs: " + coverageSourceDirs)
+        logger.debug("Coverage execution data: " + executionData)
+
+        additionalSourceDirs.setFrom files(coverageSourceDirs)
+        sourceDirectories.setFrom files(coverageSourceDirs)
+        executionData.setFrom files(coverageData)
+
+        reports {
+            xml.enabled = true
+            xml.destination = file("${buildDir}/reports/jacoco/report.xml")
+            html.enabled = true
+        }
+    }
+
+    check.dependsOn "${coverageTaskName}"
+}

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,8 +1,7 @@
-
+import com.dropbox.sample.Dependencies
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.3.72"
     repositories {
         google()
         jcenter()
@@ -12,9 +11,9 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:4.1.0"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath("org.jlleitschuh.gradle:ktlint-gradle:9.1.1")
+        classpath Dependencies.Libs.ANDROID_BUILD_TOOLS
+        classpath Dependencies.Libs.KOTLIN_GRADLE_PLUGIN
+        classpath Dependencies.Libs.KTLINT
     }
 }
 

--- a/sample/buildSrc/build.gradle.kts
+++ b/sample/buildSrc/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
 repositories {
     google()
     jcenter()
+    gradlePluginPortal()
     mavenLocal()
 }
 

--- a/sample/buildSrc/build.gradle.kts
+++ b/sample/buildSrc/build.gradle.kts
@@ -9,7 +9,6 @@ plugins {
 repositories {
     google()
     jcenter()
-    gradlePluginPortal()
     mavenLocal()
 }
 

--- a/sample/buildSrc/src/main/kotlin/com/dropbox/sample/Dependencies.kt
+++ b/sample/buildSrc/src/main/kotlin/com/dropbox/sample/Dependencies.kt
@@ -1,0 +1,21 @@
+package com.dropbox.sample
+
+object Dependencies {
+    private object Versions {
+        const val KOTLIN_VERSION = "1.4.10"
+    }
+
+    object Libs {
+        const val KOTLIN_STDLIB = "org.jetbrains.kotlin:kotlin-stdlib:${Versions.KOTLIN_VERSION}"
+        const val KOTLIN_GRADLE_PLUGIN = "org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.KOTLIN_VERSION}"
+        const val ANDROIDX_CORE_KTX = "androidx.core:core-ktx:1.3.2"
+        const val ANDROIDX_APP_COMPAT = "androidx.appcompat:appcompat:1.2.0"
+        const val ANDROID_MATERIAL = "com.google.android.material:material:1.2.1"
+        const val ANDROIDX_CONSTRAINTLAYOUT = "androidx.constraintlayout:constraintlayout:1.1.3"
+        const val JUNIT = "junit:junit:4.13.1"
+        const val ANDROIDX_TEST_EXT = "androidx.test.ext:junit:1.1.2"
+        const val ANDROIDX_ESPRESSO = "androidx.test.espresso:espresso-core:3.3.0"
+        const val ANDROID_BUILD_TOOLS = "com.android.tools.build:gradle:4.1.0"
+        const val KTLINT = "org.jlleitschuh.gradle:ktlint-gradle:9.1.1"
+    }
+}

--- a/sample/sample-app/build.gradle
+++ b/sample/sample-app/build.gradle
@@ -1,3 +1,5 @@
+import com.dropbox.sample.Dependencies
+
 plugins {
     id 'com.android.application'
     id 'kotlin-android'
@@ -46,12 +48,11 @@ dependencies {
     implementation project(":sample-core")
     implementation project(":sample-util")
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'androidx.core:core-ktx:1.2.0'
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'com.google.android.material:material:1.1.0'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    testImplementation 'junit:junit:4.+'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    implementation Dependencies.Libs.KOTLIN_STDLIB
+    implementation Dependencies.Libs.ANDROIDX_APP_COMPAT
+    implementation Dependencies.Libs.ANDROID_MATERIAL
+    implementation Dependencies.Libs.ANDROIDX_CONSTRAINTLAYOUT
+    testImplementation Dependencies.Libs.JUNIT
+    androidTestImplementation Dependencies.Libs.ANDROIDX_TEST_EXT
+    androidTestImplementation Dependencies.Libs.ANDROIDX_ESPRESSO
 }

--- a/sample/sample-app/src/main/res/layout/activity_main.xml
+++ b/sample/sample-app/src/main/res/layout/activity_main.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"

--- a/sample/sample-core/build.gradle
+++ b/sample/sample-core/build.gradle
@@ -1,3 +1,5 @@
+import com.dropbox.sample.Dependencies
+
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
@@ -36,11 +38,11 @@ dependencies {
 
     implementation project(":sample-util")
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'androidx.core:core-ktx:1.3.2'
-    implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'com.google.android.material:material:1.2.1'
-    testImplementation 'junit:junit:4.+'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    implementation Dependencies.Libs.KOTLIN_STDLIB
+    implementation Dependencies.Libs.ANDROIDX_APP_COMPAT
+    implementation Dependencies.Libs.ANDROID_MATERIAL
+    implementation Dependencies.Libs.ANDROIDX_CONSTRAINTLAYOUT
+    testImplementation Dependencies.Libs.JUNIT
+    androidTestImplementation Dependencies.Libs.ANDROIDX_TEST_EXT
+    androidTestImplementation Dependencies.Libs.ANDROIDX_ESPRESSO
 }

--- a/sample/sample-util/build.gradle
+++ b/sample/sample-util/build.gradle
@@ -1,3 +1,5 @@
+import com.dropbox.sample.Dependencies
+
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
@@ -34,11 +36,11 @@ android {
 
 dependencies {
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'androidx.core:core-ktx:1.3.2'
-    implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'com.google.android.material:material:1.2.1'
-    testImplementation 'junit:junit:4.+'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    implementation Dependencies.Libs.KOTLIN_STDLIB
+    implementation Dependencies.Libs.ANDROIDX_APP_COMPAT
+    implementation Dependencies.Libs.ANDROID_MATERIAL
+    implementation Dependencies.Libs.ANDROIDX_CONSTRAINTLAYOUT
+    testImplementation Dependencies.Libs.JUNIT
+    androidTestImplementation Dependencies.Libs.ANDROIDX_TEST_EXT
+    androidTestImplementation Dependencies.Libs.ANDROIDX_ESPRESSO
 }


### PR DESCRIPTION
This pull request does a few things:
1.  Adds running the unit tests for the detector
2. Pushes coverage result to https://codecov.io/gh/dropbox/AffectedModuleDetector
3. Adds assembling of the sample apps
4. Add a buildSrc/Dependencies.kt file for reusing dependencies in the sample app