### PR TITLE
Revert change to ensure sample is run with pull requests

### DIFF
--- a/sample/buildSrc/build.gradle.kts
+++ b/sample/buildSrc/build.gradle.kts
@@ -13,7 +13,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.dropbox.affectedmoduledetector:affectedmoduledetector:0.1.0")
+    implementation("com.dropbox.affectedmoduledetector:affectedmoduledetector:0.1.1-SNAPSHOT")
     testImplementation("junit:junit:4.13.1")
     testImplementation("com.nhaarman:mockito-kotlin:1.5.0")
     testImplementation("com.google.truth:truth:1.0.1")


### PR DESCRIPTION
Pointing the sample at `0.1.0` would have CI run against the last release.  This will ensure it will use the latest changes in the PR and on `main`.