### PR TITLE
Miken/fix run all tests

### DIFF
--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorPlugin.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorPlugin.kt
@@ -110,7 +110,7 @@ class AffectedModuleDetectorPlugin : Plugin<Project> {
                 "${project.path}:${tasks.assembleAndroidTestTask}"
         }
 
-        if (AffectedModuleDetector.isProjectProvided(project)) {
+        if (AffectedModuleDetector.isProjectAffected(project)) {
             if (project.tasks.findByPath(pathName) != null) {
                 paths.add(pathName)
             } else if (backupPath != null &&

--- a/sample/sample-app/build.gradle
+++ b/sample/sample-app/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 affectedTestConfiguration{
-    variantToTest = ""
+    variantToTest = "debug"
 }
 
 

--- a/sample/sample-core/build.gradle
+++ b/sample/sample-core/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id 'kotlin-android'
 }
 affectedTestConfiguration{
-    variantToTest = ""
+    variantToTest = "debug"
 }
 
 android {


### PR DESCRIPTION
cc @chris-mitchell we were using `isProjectProvided` within the runAll tasks, the problem was that it would return true when no modules were provided. I changed the top level call to instead call `shouldInclude` which checks whether the detector found the module AND whether `isProjectProvided2` is called.  For external usage `isProjectProvided2` will always return true, for our internal use case we can still have the list of modules. 

Verified fix in sample by changing app and core module, commiting and then runAllUnitTests 