### PR TITLE
Add subset to logs

### DIFF
--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetector.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetector.kt
@@ -173,7 +173,7 @@ abstract class AffectedModuleDetector {
                 modules = modules,
                 config = config
             ).also {
-                logger.info("Using real detector")
+                logger.info("Using real detector with $subset")
                 setInstance(
                     rootProject,
                     it


### PR DESCRIPTION
Given the different configurations that we can run with the plugin and how they are appended to the same log file I think it can be useful to have which configuration was executed.

So if we run with `ALL_AFFECTED_PROJECTS` (default) instead of having:

```
[INFO] [amd] Using real detector
```

We'd have

```
[INFO] [amd] Using real detector with ALL_AFFECTED_PROJECTS
```

This can be useful when multiple commands are executed with different configurations set.