### PR TITLE
Fix task registration

### DIFF
--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorPlugin.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorPlugin.kt
@@ -67,22 +67,21 @@ class AffectedModuleDetectorPlugin : Plugin<Project> {
     }
 
     private fun registerAffectedAndroidTests(rootProject: Project) {
-        registerAffectedTestTask("buildTestApks", TestType.ASSEMBLE_ANDROID, rootProject)
+        registerAffectedTestTask("assembleAffectedAndroidTests", TestType.ASSEMBLE_ANDROID, rootProject)
     }
 
     private fun registerAffectedTestTask(
         taskName: String, testType: TestType,
         rootProject: Project
     ) {
+        val task = rootProject.tasks.register(taskName).get()
         rootProject.subprojects { project ->
-            project.tasks.register(taskName) { task ->
-                val paths = getAffectedPaths(testType, project)
-                paths.forEach { path ->
-                    task.dependsOn(path)
-                }
-                task.enabled = paths.isNotEmpty()
-                task.onlyIf { paths.isNotEmpty() }
+            val paths = getAffectedPaths(testType, project)
+            paths.forEach { path ->
+                task.dependsOn(path)
             }
+            task.enabled = paths.isNotEmpty()
+            task.onlyIf { paths.isNotEmpty() }
         }
     }
 


### PR DESCRIPTION
Previously, we'd iteration over every project and register a task which depended on the user defined task, something like:
```
:featureA:buildTestApks -> :featureA:assembleDebugAndroidTest
:featureB:buildTestApks -> :featureB:assembleDebugAndroidTest
```

With this change, we'll register it on the root:
```
:assembleAffectedAndroidTests -> :featureA:assembleDebugAndroidTest
                              -> :featureB:assembleDebugAndroidTest
```

I think this was the intended approach all along and just a bug. 