### PR TITLE
Fix task registration in plugin

### DIFF
--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorPlugin.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorPlugin.kt
@@ -76,12 +76,14 @@ class AffectedModuleDetectorPlugin : Plugin<Project> {
     ) {
         val task = rootProject.tasks.register(taskName).get()
         rootProject.subprojects { project ->
-            val paths = getAffectedPaths(testType, project)
-            paths.forEach { path ->
-                task.dependsOn(path)
+            project.afterEvaluate {
+                val paths = getAffectedPaths(testType, project)
+                paths.forEach { path ->
+                    task.dependsOn(path)
+                }
+                task.enabled = paths.isNotEmpty()
+                task.onlyIf { paths.isNotEmpty() }
             }
-            task.enabled = paths.isNotEmpty()
-            task.onlyIf { paths.isNotEmpty() }
         }
     }
 


### PR DESCRIPTION
https://github.com/dropbox/AffectedModuleDetector/pull/39 reintroduced an error where some of the tasks weren't following the extension.  This resolves it.