### PR TITLE
Refactor affected test config 

### DIFF
--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorPlugin.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorPlugin.kt
@@ -8,7 +8,6 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.tasks.testing.Test
-import java.util.*
 
 /**
  * This plugin creates and registers all affected test tasks.
@@ -107,15 +106,23 @@ class AffectedModuleDetectorPlugin : Plugin<Project> {
         } as AffectedTestConfiguration
 
         val pathName = when (testType) {
-            is TestType.RunAndroidTest -> "${project.path}:${tasks.runAndroidTestTask}"
-            is TestType.AssembleAndroidTest -> "${project.path}:${tasks.assembleAndroidTestTask}"
-            is TestType.JvmTest -> "${project.path}:${tasks.jvmTest}"
+            is TestType.RunAndroidTest -> getPathAndTask(project, tasks.runAndroidTestTask)
+            is TestType.AssembleAndroidTest -> getPathAndTask(project, tasks.assembleAndroidTestTask)
+            is TestType.JvmTest -> getPathAndTask(project, tasks.jvmTestTask)
         }
 
         return if (AffectedModuleDetector.isProjectAffected(project)) {
             pathName
         } else {
             null
+        }
+    }
+
+    private fun getPathAndTask(project: Project, task: String?): String? {
+        return if (task.isNullOrEmpty()) {
+            null
+        } else {
+            "${project.path}:${task}"
         }
     }
 

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedTestConfiguration.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedTestConfiguration.kt
@@ -3,32 +3,14 @@ package com.dropbox.affectedmoduledetector
 /**
  * Used to configure which variant to run for affected tasks by adding following block to modules
  * affectedTestConfiguration{
- *  variantToTest = "debug"
- *  jvmTestBackup = "test"
+ *  assembleAndroidTestTask = "assembleDevDebugAndroidTest"
  * }
  */
 open class AffectedTestConfiguration {
 
-    /**
-     *  Sets variant for all affected tasks
-     *  By default `run` tasks will use debug as the variant to test ie
-     *  gradlew runAffectedUnitTests will run testDebugUnitTest
-     *
-     */
-    var variantToTest: String? = null
-        get() {
-            return field ?: "debug"
-        }
-
-    /**
-     * when [jvmTest] task is not found we will try to run [jvmTestBackup]
-     * this is normally used for modules that are not android variant aware
-     */
-    var jvmTestBackup = "test"
-
-    val assembleAndroidTestTask get() = "assemble${variantToTest?.capitalize()}AndroidTest"
-    val runAndroidTestTask get() = "connected${variantToTest?.capitalize()}AndroidTest"
-    val jvmTest get() = "test${variantToTest?.capitalize()}UnitTest"
+    var assembleAndroidTestTask = "assembleDebugAndroidTest"
+    var runAndroidTestTask  = "connectedDebugAndroidTest"
+    var jvmTest = "testDebugUnitTest"
 
     companion object {
         const val name = "affectedTestConfiguration"

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedTestConfiguration.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedTestConfiguration.kt
@@ -8,9 +8,9 @@ package com.dropbox.affectedmoduledetector
  */
 open class AffectedTestConfiguration {
 
-    var assembleAndroidTestTask = "assembleDebugAndroidTest"
-    var runAndroidTestTask  = "connectedDebugAndroidTest"
-    var jvmTest = "testDebugUnitTest"
+    var assembleAndroidTestTask : String? = "assembleDebugAndroidTest"
+    var runAndroidTestTask : String?  = "connectedDebugAndroidTest"
+    var jvmTestTask : String? = "testDebugUnitTest"
 
     companion object {
         const val name = "affectedTestConfiguration"

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorPluginTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorPluginTest.kt
@@ -4,7 +4,6 @@ import com.google.common.truth.Truth.assertThat
 import junit.framework.Assert.fail
 import org.gradle.api.Project
 import org.gradle.api.internal.project.DefaultProject
-import org.gradle.api.plugins.JavaLibraryPlugin
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Before
 import org.junit.Rule
@@ -94,7 +93,7 @@ class AffectedModuleDetectorPluginTest {
         // WHEN
         rootProject.pluginManager.apply(AffectedModuleDetectorPlugin::class.java)
         val ext = requireNotNull(childProject.extensions.findByType(AffectedTestConfiguration::class.java))
-        ext.jvmTest = "myfaketest"
+        ext.jvmTestTask = "myfaketest"
 
         (rootProject as DefaultProject).evaluate()
 

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedTestConfigurationTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedTestConfigurationTest.kt
@@ -17,7 +17,7 @@ class AffectedTestConfigurationTest {
     fun `GIVEN AffectedTestConfiguration WHEN default values THEN default values returned`() {
         assertThat(config.assembleAndroidTestTask).isEqualTo("assembleDebugAndroidTest")
         assertThat(config.runAndroidTestTask).isEqualTo("connectedDebugAndroidTest")
-        assertThat(config.jvmTest).isEqualTo("testDebugUnitTest")
+        assertThat(config.jvmTestTask).isEqualTo("testDebugUnitTest")
     }
 
     @Test
@@ -30,12 +30,12 @@ class AffectedTestConfigurationTest {
         // WHEN
         config.assembleAndroidTestTask = assembleAndroidTestTask
         config.runAndroidTestTask = runAndroidTestTask
-        config.jvmTest = jvmTest
+        config.jvmTestTask = jvmTest
 
         // THEN
         assertThat(config.assembleAndroidTestTask).isEqualTo(assembleAndroidTestTask)
         assertThat(config.runAndroidTestTask).isEqualTo(runAndroidTestTask)
-        assertThat(config.jvmTest).isEqualTo(jvmTest)
+        assertThat(config.jvmTestTask).isEqualTo(jvmTest)
     }
 
     @Test

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedTestConfigurationTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedTestConfigurationTest.kt
@@ -14,71 +14,28 @@ class AffectedTestConfigurationTest {
     }
 
     @Test
-    fun `GIVEN AffectedTestConfiguration WHEN default value of variant to test THEN debug is returned`() {
-        assertThat(config.variantToTest).isEqualTo("debug")
-    }
-
-    @Test
-    fun `GIVEN AffectedTestConfiguration WHEN variant to test is set THEN value is returned`() {
-        // GIVEN
-        val sample = "sample"
-
-        // WHEN
-        config.variantToTest = sample
-
-        // THEN
-        assertThat(config.variantToTest).isEqualTo(sample)
-    }
-
-    @Test
-    fun `GIVEN AffectedTestConfiguration WHEN assemble android test task is called THEN default is returned`() {
+    fun `GIVEN AffectedTestConfiguration WHEN default values THEN default values returned`() {
         assertThat(config.assembleAndroidTestTask).isEqualTo("assembleDebugAndroidTest")
-    }
-
-    @Test
-    fun `GIVEN AffectedTestConfiguration WHEN variant is setup and assemble android test task is called THEN variant task is returned`() {
-        // GIVEN
-        config.variantToTest = "sample"
-
-        // WHEN
-        val task = config.assembleAndroidTestTask
-
-        // THEN
-        assertThat(task).isEqualTo("assembleSampleAndroidTest")
-    }
-
-    @Test
-    fun `GIVEN AffectedTestConfiguration WHEN run android test task is called THEN default is returned`() {
         assertThat(config.runAndroidTestTask).isEqualTo("connectedDebugAndroidTest")
-    }
-
-    @Test
-    fun `GIVEN AffectedTestConfiguration WHEN variant is setup and run android test task is called THEN variant task is returned`() {
-        // GIVEN
-        config.variantToTest = "sample"
-
-        // WHEN
-        val task = config.runAndroidTestTask
-
-        // THEN
-        assertThat(task).isEqualTo("connectedSampleAndroidTest")
-    }
-
-    @Test
-    fun `GIVEN AffectedTestConfiguration WHEN jvm test is called THEN default is returned`() {
         assertThat(config.jvmTest).isEqualTo("testDebugUnitTest")
     }
 
     @Test
-    fun `GIVEN AffectedTestConfiguration WHEN variant is setup and jvm test is called THEN variant task is returned`() {
+    fun `GIVEN AffectedTestConfiguration WHEN values are updated THEN new values are returned`() {
         // GIVEN
-        config.variantToTest = "sample"
+        val assembleAndroidTestTask = "assembleAndroidTestTask"
+        val runAndroidTestTask = "runAndroidTestTask"
+        val jvmTest = "jvmTest"
 
         // WHEN
-        val task = config.jvmTest
+        config.assembleAndroidTestTask = assembleAndroidTestTask
+        config.runAndroidTestTask = runAndroidTestTask
+        config.jvmTest = jvmTest
 
         // THEN
-        assertThat(task).isEqualTo("testSampleUnitTest")
+        assertThat(config.assembleAndroidTestTask).isEqualTo(assembleAndroidTestTask)
+        assertThat(config.runAndroidTestTask).isEqualTo(runAndroidTestTask)
+        assertThat(config.jvmTest).isEqualTo(jvmTest)
     }
 
     @Test

--- a/gradle/releasing.gradle
+++ b/gradle/releasing.gradle
@@ -1,6 +1,6 @@
 ext {
     DESCRIPTION = "A Gradle Plugin and library to determine which modules were affected in a commit."
-    VERSION = "0.1.1-SNAPSHOT"
+    VERSION = "0.1.2-SNAPSHOT"
     GIT_URL = 'https://github.com/Dropbox/AffectedModuleDetector'
     GROUP_ID = "com.dropbox.affectedmoduledetector"
     SONATYPE_SNAPSHOT_URL = "https://oss.sonatype.org/content/repositories/snapshots/"

--- a/sample/sample-app/build.gradle
+++ b/sample/sample-app/build.gradle
@@ -5,8 +5,8 @@ plugins {
     id 'kotlin-android'
 }
 
-affectedTestConfiguration{
-    variantToTest = "debug"
+affectedTestConfiguration {
+    assembleAndroidTestTask = "assembleAndroidTest"
 }
 
 

--- a/sample/sample-core/build.gradle
+++ b/sample/sample-core/build.gradle
@@ -4,8 +4,9 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
 }
-affectedTestConfiguration{
-    variantToTest = "debug"
+
+affectedTestConfiguration {
+    jvmTest = "test"
 }
 
 android {

--- a/sample/sample-util/build.gradle
+++ b/sample/sample-util/build.gradle
@@ -5,6 +5,10 @@ plugins {
     id 'kotlin-android'
 }
 
+affectedTestConfiguration {
+    assembleAndroidTestTask = "assembleDebugAndroidTest"
+}
+
 android {
     compileSdkVersion 30
     buildToolsVersion "30.0.2"


### PR DESCRIPTION
Updates the way we define our extension so that consumers can simply define the entire name of the task to run for jvm / assemble android test / run android test.  See the sample app for examples. 