### PR TITLE
Ensure calls to configure are run after all projects have been configured

### DIFF
--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetector.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetector.kt
@@ -114,6 +114,16 @@ abstract class AffectedModuleDetector {
 
         @JvmStatic
         fun configure(gradle: Gradle, rootProject: Project) {
+            require(rootProject == rootProject.rootProject) {
+                "Project provided must be root, project was ${rootProject.path}"
+            }
+
+            // Configure method must run after all projects have been evaluated
+            rootProject.allprojects { project ->
+                require(project.state.executed) {
+                    "$project wasn't evaluated, ensure all projects have been evaluated before calling configure.`"
+                }
+            }
             val enabled = rootProject.hasProperty(ENABLE_ARG)
             if (!enabled) {
                 setInstance(

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorPlugin.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorPlugin.kt
@@ -42,17 +42,16 @@ class AffectedModuleDetectorPlugin : Plugin<Project> {
             "Must be applied to root project, but was found on ${project.path} instead."
         }
         registerExtensions(project)
-        AffectedModuleDetector.configure(project.gradle, project)
+        project.gradle.projectsEvaluated {
+            AffectedModuleDetector.configure(project.gradle, project)
 
-
-        project.afterEvaluate {
             registerAffectedAndroidTests(project)
             registerAffectedConnectedTestTask(project)
             registerJVMTests(project)
-        }
 
-        filterAndroidTests(project)
-        filterUnitTests(project)
+            filterAndroidTests(project)
+            filterUnitTests(project)
+        }
     }
 
     private fun registerJVMTests(project: Project) {
@@ -74,14 +73,12 @@ class AffectedModuleDetectorPlugin : Plugin<Project> {
     ) {
         val task = rootProject.tasks.register(taskName).get()
         rootProject.subprojects { project ->
-            project.afterEvaluate {
-                val paths = getAffectedPaths(testType, project)
-                paths.forEach { path ->
-                    task.dependsOn(path)
-                }
-                task.enabled = paths.isNotEmpty()
-                task.onlyIf { paths.isNotEmpty() }
+            val paths = getAffectedPaths(testType, project)
+            paths.forEach { path ->
+                task.dependsOn(path)
             }
+            task.enabled = paths.isNotEmpty()
+            task.onlyIf { paths.isNotEmpty() }
         }
     }
 

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorPlugin.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorPlugin.kt
@@ -72,6 +72,7 @@ class AffectedModuleDetectorPlugin : Plugin<Project> {
         rootProject: Project
     ) {
         val task = rootProject.tasks.register(taskName).get()
+        task.group = TASK_GROUP_NAME
         rootProject.subprojects { project ->
             val paths = getAffectedPaths(testType, project)
             paths.forEach { path ->
@@ -152,5 +153,8 @@ class AffectedModuleDetectorPlugin : Plugin<Project> {
         }
     }
 
+    companion object {
+        const val TASK_GROUP_NAME = "Affected Module Detector"
+    }
 
 }


### PR DESCRIPTION
The module detector was being configured mid-way through the project graph evaluation.  This caused some project relations to not be identified and projects to be missed. 

This pushes the plugins call until after the projects have been evaluated, and implements a check to ensure everything has been evaluated before proceeding. 