### PR TITLE
Use onlyIf block to disable tasks

### DIFF
--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetector.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetector.kt
@@ -117,13 +117,7 @@ abstract class AffectedModuleDetector {
             require(rootProject == rootProject.rootProject) {
                 "Project provided must be root, project was ${rootProject.path}"
             }
-
-            // Configure method must run after all projects have been evaluated
-            rootProject.allprojects { project ->
-                require(project.state.executed) {
-                    "$project wasn't evaluated, ensure all projects have been evaluated before calling configure.`"
-                }
-            }
+            
             val enabled = rootProject.hasProperty(ENABLE_ARG)
             if (!enabled) {
                 setInstance(

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorPlugin.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorPlugin.kt
@@ -40,12 +40,12 @@ class AffectedModuleDetectorPlugin : Plugin<Project> {
             "Must be applied to root project, but was found on ${project.path} instead."
         }
         registerExtensions(project)
+        registerAffectedAndroidTests(project)
+        registerAffectedConnectedTestTask(project)
+        registerJvmTests(project)
+
         project.gradle.projectsEvaluated {
             AffectedModuleDetector.configure(project.gradle, project)
-
-            registerAffectedAndroidTests(project)
-            registerAffectedConnectedTestTask(project)
-            registerJvmTests(project)
 
             filterAndroidTests(project)
             filterJvmTests(project)
@@ -73,16 +73,19 @@ class AffectedModuleDetectorPlugin : Plugin<Project> {
         task.description = testType.description
 
         rootProject.subprojects { project ->
-            val pluginIds = setOf("com.android.application", "com.android.library", "java-library", "kotlin")
-            pluginIds.forEach { pluginId ->
-                if (pluginId == "java-library" || pluginId == "kotlin") {
-                    if (testType is TestType.JvmTest ) {
+            project.afterEvaluate {
+                val pluginIds = setOf("com.android.application", "com.android.library", "java-library", "kotlin")
+                pluginIds.forEach { pluginId ->
+                    if (pluginId == "java-library" || pluginId == "kotlin") {
+                        if (testType is TestType.JvmTest ) {
+                            withPlugin(pluginId, task, testType, project)
+                        }
+                    } else {
                         withPlugin(pluginId, task, testType, project)
                     }
-                } else {
-                    withPlugin(pluginId, task, testType, project)
                 }
             }
+
         }
     }
 
@@ -91,7 +94,11 @@ class AffectedModuleDetectorPlugin : Plugin<Project> {
             val path = getAffectedPath(testType, project)
             path?.let {
                 task.dependsOn(it)
+                project.tasks.findByPath(it)?.onlyIf {
+                    AffectedModuleDetector.isProjectAffected(project)
+                }
             }
+
         }
     }
 
@@ -105,16 +112,10 @@ class AffectedModuleDetectorPlugin : Plugin<Project> {
             "Unable to find ${AffectedTestConfiguration.name} in $project"
         } as AffectedTestConfiguration
 
-        val pathName = when (testType) {
+        return when (testType) {
             is TestType.RunAndroidTest -> getPathAndTask(project, tasks.runAndroidTestTask)
             is TestType.AssembleAndroidTest -> getPathAndTask(project, tasks.assembleAndroidTestTask)
             is TestType.JvmTest -> getPathAndTask(project, tasks.jvmTestTask)
-        }
-
-        return if (AffectedModuleDetector.isProjectAffected(project)) {
-            pathName
-        } else {
-            null
         }
     }
 


### PR DESCRIPTION
Aggregate all the necessary tasks, and skip them by using the onlyIf block. 

After `projectsEvaluate` was evaluate, the task graph could not be manipulated, effectively resulting in a no op.  