### PR TITLE
Add ability to compare between fork point

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,17 @@ affectedModuleDetector {
     ]
     logFilename = "output.log"
     logFolder = "${project.rootDir}/output"
+    compareFrom = "PreviousCommit" //default is PreviousCommit
 }
 ```
 
- - `baseDir`: The root directory for all of the `pathsAffectingAllModules`.  Used to validate the paths exist.
+ - `baseDir`: The root directory for all of the `pathsAffectingAllModules`. Used to validate the paths exist.
  - `pathsAffectingAllModules`: Paths to files or folders which if changed will trigger all modules to be considered affected
  - `logFilename`: A filename for the output detector to use
  - `logFolder`: A folder to output the log file in
+ - `compareFrom`: A commit to compare the branch changes against. Can be either:
+    - PreviousCommit: compare against the previous commit
+    - ForkCommit: compare against the commit the branch was forked from
  
  
  

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleConfiguration.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleConfiguration.kt
@@ -37,6 +37,15 @@ class AffectedModuleConfiguration {
             return field
         }
 
+    var compareFrom: String = "PreviousCommit"
+    set(value) {
+        val commitShaProviders = listOf("PreviousCommit", "ForkCommit")
+        require(commitShaProviders.contains(value)) {
+            "The property configuration compareFrom must be one of the following: ${commitShaProviders.joinToString(", ")}"
+        }
+        field = value
+    }
+
     companion object {
         const val name = "affectedModuleDetector"
     }

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetector.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetector.kt
@@ -25,6 +25,7 @@ import com.dropbox.affectedmoduledetector.AffectedModuleDetector.Companion.CHANG
 import com.dropbox.affectedmoduledetector.AffectedModuleDetector.Companion.DEPENDENT_PROJECTS_ARG
 import com.dropbox.affectedmoduledetector.AffectedModuleDetector.Companion.ENABLE_ARG
 import com.dropbox.affectedmoduledetector.AffectedModuleDetector.Companion.MODULES_ARG
+import com.dropbox.affectedmoduledetector.commitshaproviders.CommitShaProvider
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -335,7 +336,7 @@ class AffectedModuleDetectorImpl constructor(
         injectedGitClient ?: GitClientImpl(
             rootProject.projectDir,
             logger,
-            config = config
+            commitShaProvider = CommitShaProvider.fromString(config.compareFrom)
         )
     }
 

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetector.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetector.kt
@@ -406,9 +406,7 @@ class AffectedModuleDetectorImpl constructor(
      * Also populates the unknownFiles var which is used in findAffectedProjects
      */
     private fun findChangedProjects(): Set<Project> {
-        val changedFiles = git.findChangedFiles(
-            includeUncommitted = true
-        )
+        val changedFiles = git.findChangedFiles(true)
 
         val changedProjects = mutableSetOf<Project>()
 

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetector.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetector.kt
@@ -334,7 +334,8 @@ class AffectedModuleDetectorImpl constructor(
     private val git by lazy {
         injectedGitClient ?: GitClientImpl(
             rootProject.projectDir,
-            logger
+            logger,
+            config = config
         )
     }
 
@@ -404,9 +405,7 @@ class AffectedModuleDetectorImpl constructor(
      * Also populates the unknownFiles var which is used in findAffectedProjects
      */
     private fun findChangedProjects(): Set<Project> {
-        val lastMergeSha = git.findPreviousCommitSha() ?: return allProjects
-        val changedFiles = git.findChangedFilesSince(
-            sha = lastMergeSha,
+        val changedFiles = git.findChangedFiles(
             includeUncommitted = true
         )
 

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetector.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetector.kt
@@ -406,7 +406,9 @@ class AffectedModuleDetectorImpl constructor(
      * Also populates the unknownFiles var which is used in findAffectedProjects
      */
     private fun findChangedProjects(): Set<Project> {
-        val changedFiles = git.findChangedFiles(true)
+        val changedFiles = git.findChangedFiles(
+            includeUncommitted = true
+        )
 
         val changedProjects = mutableSetOf<Project>()
 

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetector.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetector.kt
@@ -399,14 +399,14 @@ class AffectedModuleDetectorImpl constructor(
     }
 
     /**
-     * Finds only the set of projects that were directly changed in the commit.
+     * Finds only the set of projects that were directly changed since the last master commit.
      *
      * Also populates the unknownFiles var which is used in findAffectedProjects
      */
     private fun findChangedProjects(): Set<Project> {
-        val lastMergeSha = git.findPreviousCommitSha() ?: return allProjects
+        val lastMasterCommitSha = git.findLastMasterCommit() ?: return allProjects
         val changedFiles = git.findChangedFilesSince(
-            sha = lastMergeSha,
+            sha = lastMasterCommitSha,
             includeUncommitted = true
         )
 

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetector.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetector.kt
@@ -399,14 +399,14 @@ class AffectedModuleDetectorImpl constructor(
     }
 
     /**
-     * Finds only the set of projects that were directly changed since the last master commit.
+     * Finds only the set of projects that were directly changed in the commit.
      *
      * Also populates the unknownFiles var which is used in findAffectedProjects
      */
     private fun findChangedProjects(): Set<Project> {
-        val lastMasterCommitSha = git.findLastMasterCommit() ?: return allProjects
+        val lastMergeSha = git.findPreviousCommitSha() ?: return allProjects
         val changedFiles = git.findChangedFilesSince(
-            sha = lastMasterCommitSha,
+            sha = lastMergeSha,
             includeUncommitted = true
         )
 

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/CommitShaProvider.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/CommitShaProvider.kt
@@ -1,0 +1,58 @@
+package com.dropbox.affectedmoduledetector
+
+interface CommitShaProvider {
+    fun getCommitSha(commandRunner: GitClient.CommandRunner): Sha?
+
+    companion object {
+        fun fromString(string: String): CommitShaProvider {
+            return when (string) {
+                "PreviousCommit" -> PreviousCommit()
+                else -> ForkCommit()
+            }
+        }
+    }
+}
+
+class PreviousCommit: CommitShaProvider {
+    override fun getCommitSha(commandRunner: GitClient.CommandRunner): Sha? {
+        return commandRunner.executeAndParse(PREV_COMMIT_CMD)
+            .firstOrNull()
+            ?.split(" ")
+            ?.firstOrNull()
+    }
+    companion object {
+        const val PREV_COMMIT_CMD = "git --no-pager rev-parse HEAD~1"
+    }
+}
+
+class ForkCommit: CommitShaProvider {
+    override fun getCommitSha(commandRunner: GitClient.CommandRunner): Sha? {
+        val currentBranch = commandRunner.executeAndParse(CURRENT_BRANCH_CMD).firstOrNull()
+
+        requireNotNull(currentBranch) {
+            "Current branch not found"
+        }
+
+        val parentBranch = commandRunner.executeAndParse(SHOW_ALL_BRANCHES_CMD)
+            .filter { it.contains("*") }
+            .first { !it.contains(currentBranch) }
+            .substringAfter("[")
+            .substringBefore("]")
+            .substringBefore("~")
+            .substringBefore("^")
+
+        require(parentBranch.isNotEmpty()) {
+            "Parent branch not found"
+        }
+
+        return commandRunner.executeAndParse("git merge-base $currentBranch $parentBranch")
+            .firstOrNull()
+            ?.split(" ")
+            ?.firstOrNull()
+    }
+
+    companion object {
+        const val CURRENT_BRANCH_CMD = "git rev-parse --abbrev-ref HEAD"
+        const val SHOW_ALL_BRANCHES_CMD = "git show-branch -a"
+    }
+}

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/GitClient.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/GitClient.kt
@@ -184,7 +184,7 @@ internal class GitClientImpl(
                     ?.split(" ")
                     ?.firstOrNull()
             ) {
-                "No first value from command: $command"
+                "No value from command: $command provided"
             }
         }
     }

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/GitClient.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/GitClient.kt
@@ -20,6 +20,7 @@
 
 package com.dropbox.affectedmoduledetector
 
+import com.dropbox.affectedmoduledetector.commitshaproviders.CommitShaProvider
 import java.io.File
 import java.util.concurrent.TimeUnit
 import org.gradle.api.logging.Logger

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/GitClient.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/GitClient.kt
@@ -77,7 +77,7 @@ internal class GitClientImpl(
         top: Sha,
         includeUncommitted: Boolean
     ): List<String> {
-        val sha = commitShaProvider.getCommitSha(commandRunner)
+        val sha = commitShaProvider.get(commandRunner)
 
         // use this if we don't want local changes
         return commandRunner.executeAndParse(if (includeUncommitted) {

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/GitClient.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/GitClient.kt
@@ -30,7 +30,7 @@ interface GitClient {
         top: Sha = "HEAD",
         includeUncommitted: Boolean = false
     ): List<String>
-    fun findPreviousCommitSha(): Sha?
+    fun findLastMasterCommit(): Sha?
 
     fun getGitRoot(): File
 
@@ -86,8 +86,8 @@ internal class GitClientImpl(
     /**
      * Checks the history to find the first merge CL.
      */
-    override fun findPreviousCommitSha(): String? {
-        return commandRunner.executeAndParse(PREV_COMMIT_CMD)
+    override fun findLastMasterCommit(): String? {
+        return commandRunner.executeAndParse(LAST_MASTER_COMMIT_CMD)
                 .firstOrNull()
                 ?.split(" ")
                 ?.firstOrNull()
@@ -181,6 +181,7 @@ internal class GitClientImpl(
     companion object {
         const val PREV_COMMIT_CMD = "git --no-pager rev-parse HEAD~1"
         const val PREV_MERGE_CMD = "git show-branch -a | grep '\\*' | grep -v `git rev-parse --abbrev-ref HEAD` | head -n1 | sed 's/.*\\[\\(.*\\)\\].*/\\1/' | sed 's/[\\^~].*//'"
+        const val LAST_MASTER_COMMIT_CMD = "git log -n 1 master --format=format:\"%H\""
         const val CHANGED_FILES_CMD_PREFIX = "git --no-pager diff --name-only"
     }
 }

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/GitClient.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/GitClient.kt
@@ -44,6 +44,10 @@ interface GitClient {
          * Executes the given shell command and returns the stdout by lines.
          */
         fun executeAndParse(command: String): List<String>
+        /**
+         * Executes the given shell command and returns the first stdout line.
+         */
+        fun executeAndParseFirst(command: String): String
     }
 }
 
@@ -74,9 +78,6 @@ internal class GitClientImpl(
         includeUncommitted: Boolean
     ): List<String> {
         val sha = getCommitSha()
-        requireNotNull(sha) {
-            "No commit sha to compare current branch changes against"
-        }
 
         // use this if we don't want local changes
         return commandRunner.executeAndParse(if (includeUncommitted) {
@@ -86,7 +87,7 @@ internal class GitClientImpl(
         })
     }
 
-    private fun getCommitSha(): Sha? {
+    private fun getCommitSha(): Sha {
         val commitShaProvider = CommitShaProvider.fromString(config.compareFrom)
 
         return commitShaProvider.getCommitSha(commandRunner)
@@ -174,6 +175,17 @@ internal class GitClientImpl(
                     it.isEmpty()
                 }
             return response
+        }
+
+        override fun executeAndParseFirst(command: String): String {
+            return requireNotNull(
+                executeAndParse(command)
+                    .firstOrNull()
+                    ?.split(" ")
+                    ?.firstOrNull()
+            ) {
+                "No first value from command: $command"
+            }
         }
     }
 

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/GitClient.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/GitClient.kt
@@ -27,7 +27,6 @@ import org.gradle.api.logging.Logger
 
 interface GitClient {
     fun findChangedFiles(
-        top: Sha = "HEAD",
         includeUncommitted: Boolean = false
     ): List<String>
     fun getGitRoot(): File
@@ -74,7 +73,6 @@ internal class GitClientImpl(
      * Finds changed file paths
      */
     override fun findChangedFiles(
-        top: Sha,
         includeUncommitted: Boolean
     ): List<String> {
         val sha = commitShaProvider.get(commandRunner)
@@ -83,6 +81,7 @@ internal class GitClientImpl(
         return commandRunner.executeAndParse(if (includeUncommitted) {
             "$CHANGED_FILES_CMD_PREFIX HEAD..$sha"
         } else {
+            val top = commandRunner.executeAndParseFirst(TOP_COMMIT_CMD)
             "$CHANGED_FILES_CMD_PREFIX $top $sha"
         })
     }
@@ -185,6 +184,7 @@ internal class GitClientImpl(
 
     companion object {
         const val CHANGED_FILES_CMD_PREFIX = "git --no-pager diff --name-only"
+        const val TOP_COMMIT_CMD = "git --no-pager rev-parse HEAD"
     }
 }
 

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/GitClient.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/GitClient.kt
@@ -67,7 +67,7 @@ internal class GitClientImpl(
         workingDir = workingDir,
         logger = logger
     ),
-    private val config: AffectedModuleConfiguration
+    private val commitShaProvider: CommitShaProvider
 ) : GitClient {
 
     /**
@@ -77,7 +77,7 @@ internal class GitClientImpl(
         top: Sha,
         includeUncommitted: Boolean
     ): List<String> {
-        val sha = getCommitSha()
+        val sha = commitShaProvider.getCommitSha(commandRunner)
 
         // use this if we don't want local changes
         return commandRunner.executeAndParse(if (includeUncommitted) {
@@ -85,12 +85,6 @@ internal class GitClientImpl(
         } else {
             "$CHANGED_FILES_CMD_PREFIX $top $sha"
         })
-    }
-
-    private fun getCommitSha(): Sha {
-        val commitShaProvider = CommitShaProvider.fromString(config.compareFrom)
-
-        return commitShaProvider.getCommitSha(commandRunner)
     }
 
     private fun findGitDirInParentFilepath(filepath: File): File? {

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/GitClient.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/GitClient.kt
@@ -27,6 +27,7 @@ import org.gradle.api.logging.Logger
 
 interface GitClient {
     fun findChangedFiles(
+        top: Sha = "HEAD",
         includeUncommitted: Boolean = false
     ): List<String>
     fun getGitRoot(): File
@@ -73,6 +74,7 @@ internal class GitClientImpl(
      * Finds changed file paths
      */
     override fun findChangedFiles(
+        top: Sha,
         includeUncommitted: Boolean
     ): List<String> {
         val sha = commitShaProvider.get(commandRunner)
@@ -81,7 +83,6 @@ internal class GitClientImpl(
         return commandRunner.executeAndParse(if (includeUncommitted) {
             "$CHANGED_FILES_CMD_PREFIX HEAD..$sha"
         } else {
-            val top = commandRunner.executeAndParseFirst(TOP_COMMIT_CMD)
             "$CHANGED_FILES_CMD_PREFIX $top $sha"
         })
     }
@@ -184,7 +185,6 @@ internal class GitClientImpl(
 
     companion object {
         const val CHANGED_FILES_CMD_PREFIX = "git --no-pager diff --name-only"
-        const val TOP_COMMIT_CMD = "git --no-pager rev-parse HEAD"
     }
 }
 

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/GitClient.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/GitClient.kt
@@ -30,7 +30,7 @@ interface GitClient {
         top: Sha = "HEAD",
         includeUncommitted: Boolean = false
     ): List<String>
-    fun findLastMasterCommit(): Sha?
+    fun findPreviousCommitSha(): Sha?
 
     fun getGitRoot(): File
 
@@ -86,8 +86,8 @@ internal class GitClientImpl(
     /**
      * Checks the history to find the first merge CL.
      */
-    override fun findLastMasterCommit(): String? {
-        return commandRunner.executeAndParse(LAST_MASTER_COMMIT_CMD)
+    override fun findPreviousCommitSha(): String? {
+        return commandRunner.executeAndParse(PREV_COMMIT_CMD)
                 .firstOrNull()
                 ?.split(" ")
                 ?.firstOrNull()
@@ -181,7 +181,6 @@ internal class GitClientImpl(
     companion object {
         const val PREV_COMMIT_CMD = "git --no-pager rev-parse HEAD~1"
         const val PREV_MERGE_CMD = "git show-branch -a | grep '\\*' | grep -v `git rev-parse --abbrev-ref HEAD` | head -n1 | sed 's/.*\\[\\(.*\\)\\].*/\\1/' | sed 's/[\\^~].*//'"
-        const val LAST_MASTER_COMMIT_CMD = "git log -n 1 master --format=format:\"%H\""
         const val CHANGED_FILES_CMD_PREFIX = "git --no-pager diff --name-only"
     }
 }

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/CommitShaProvider.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/CommitShaProvider.kt
@@ -1,0 +1,18 @@
+package com.dropbox.affectedmoduledetector.commitshaproviders
+
+import com.dropbox.affectedmoduledetector.GitClient
+import com.dropbox.affectedmoduledetector.Sha
+
+interface CommitShaProvider {
+    fun getCommitSha(commandRunner: GitClient.CommandRunner): Sha?
+
+    companion object {
+        fun fromString(string: String): CommitShaProvider {
+            return when (string) {
+                "PreviousCommit" -> PreviousCommit()
+                else -> ForkCommit()
+            }
+        }
+    }
+}
+

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/CommitShaProvider.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/CommitShaProvider.kt
@@ -4,7 +4,7 @@ import com.dropbox.affectedmoduledetector.GitClient
 import com.dropbox.affectedmoduledetector.Sha
 
 interface CommitShaProvider {
-    fun getCommitSha(commandRunner: GitClient.CommandRunner): Sha
+    fun get(commandRunner: GitClient.CommandRunner): Sha
 
     companion object {
         fun fromString(string: String): CommitShaProvider {

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/CommitShaProvider.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/CommitShaProvider.kt
@@ -10,7 +10,8 @@ interface CommitShaProvider {
         fun fromString(string: String): CommitShaProvider {
             return when (string) {
                 "PreviousCommit" -> PreviousCommit()
-                else -> ForkCommit()
+                "ForkCommit" -> ForkCommit()
+                else -> throw IllegalArgumentException("Unsupported compareFrom type")
             }
         }
     }

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/CommitShaProvider.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/CommitShaProvider.kt
@@ -4,7 +4,7 @@ import com.dropbox.affectedmoduledetector.GitClient
 import com.dropbox.affectedmoduledetector.Sha
 
 interface CommitShaProvider {
-    fun getCommitSha(commandRunner: GitClient.CommandRunner): Sha?
+    fun getCommitSha(commandRunner: GitClient.CommandRunner): Sha
 
     companion object {
         fun fromString(string: String): CommitShaProvider {

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/ForkCommit.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/ForkCommit.kt
@@ -5,7 +5,10 @@ import com.dropbox.affectedmoduledetector.Sha
 
 class ForkCommit: CommitShaProvider {
     override fun getCommitSha(commandRunner: GitClient.CommandRunner): Sha? {
-        val currentBranch = commandRunner.executeAndParse(CURRENT_BRANCH_CMD).firstOrNull()
+        val currentBranch = commandRunner.executeAndParse(CURRENT_BRANCH_CMD)
+            .firstOrNull()
+            ?.split(" ")
+            ?.firstOrNull()
 
         requireNotNull(currentBranch) {
             "Current branch not found"

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/ForkCommit.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/ForkCommit.kt
@@ -4,7 +4,7 @@ import com.dropbox.affectedmoduledetector.GitClient
 import com.dropbox.affectedmoduledetector.Sha
 
 class ForkCommit: CommitShaProvider {
-    override fun getCommitSha(commandRunner: GitClient.CommandRunner): Sha {
+    override fun get(commandRunner: GitClient.CommandRunner): Sha {
         val currentBranch = commandRunner.executeAndParseFirst(CURRENT_BRANCH_CMD)
 
         val parentBranch = commandRunner.executeAndParse(SHOW_ALL_BRANCHES_CMD)

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/ForkCommit.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/ForkCommit.kt
@@ -8,13 +8,13 @@ class ForkCommit: CommitShaProvider {
         val currentBranch = commandRunner.executeAndParseFirst(CURRENT_BRANCH_CMD)
 
         val parentBranch = commandRunner.executeAndParse(SHOW_ALL_BRANCHES_CMD)
-            .first { !it.contains(currentBranch) && it.contains("*") }
-            .substringAfter("[")
-            .substringBefore("]")
-            .substringBefore("~")
-            .substringBefore("^")
+            .firstOrNull { !it.contains(currentBranch) && it.contains("*") }
+            ?.substringAfter("[")
+            ?.substringBefore("]")
+            ?.substringBefore("~")
+            ?.substringBefore("^")
 
-        require(parentBranch.isNotEmpty()) {
+        requireNotNull(parentBranch) {
             "Parent branch not found"
         }
 

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/ForkCommit.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/ForkCommit.kt
@@ -1,29 +1,7 @@
-package com.dropbox.affectedmoduledetector
+package com.dropbox.affectedmoduledetector.commitshaproviders
 
-interface CommitShaProvider {
-    fun getCommitSha(commandRunner: GitClient.CommandRunner): Sha?
-
-    companion object {
-        fun fromString(string: String): CommitShaProvider {
-            return when (string) {
-                "PreviousCommit" -> PreviousCommit()
-                else -> ForkCommit()
-            }
-        }
-    }
-}
-
-class PreviousCommit: CommitShaProvider {
-    override fun getCommitSha(commandRunner: GitClient.CommandRunner): Sha? {
-        return commandRunner.executeAndParse(PREV_COMMIT_CMD)
-            .firstOrNull()
-            ?.split(" ")
-            ?.firstOrNull()
-    }
-    companion object {
-        const val PREV_COMMIT_CMD = "git --no-pager rev-parse HEAD~1"
-    }
-}
+import com.dropbox.affectedmoduledetector.GitClient
+import com.dropbox.affectedmoduledetector.Sha
 
 class ForkCommit: CommitShaProvider {
     override fun getCommitSha(commandRunner: GitClient.CommandRunner): Sha? {

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/ForkCommit.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/ForkCommit.kt
@@ -12,8 +12,7 @@ class ForkCommit: CommitShaProvider {
         }
 
         val parentBranch = commandRunner.executeAndParse(SHOW_ALL_BRANCHES_CMD)
-            .filter { it.contains("*") }
-            .first { !it.contains(currentBranch) }
+            .first { !it.contains(currentBranch) && it.contains("*") }
             .substringAfter("[")
             .substringBefore("]")
             .substringBefore("~")

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/ForkCommit.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/ForkCommit.kt
@@ -4,11 +4,8 @@ import com.dropbox.affectedmoduledetector.GitClient
 import com.dropbox.affectedmoduledetector.Sha
 
 class ForkCommit: CommitShaProvider {
-    override fun getCommitSha(commandRunner: GitClient.CommandRunner): Sha? {
-        val currentBranch = commandRunner.executeAndParse(CURRENT_BRANCH_CMD)
-            .firstOrNull()
-            ?.split(" ")
-            ?.firstOrNull()
+    override fun getCommitSha(commandRunner: GitClient.CommandRunner): Sha {
+        val currentBranch = commandRunner.executeAndParseFirst(CURRENT_BRANCH_CMD)
 
         requireNotNull(currentBranch) {
             "Current branch not found"
@@ -25,10 +22,7 @@ class ForkCommit: CommitShaProvider {
             "Parent branch not found"
         }
 
-        return commandRunner.executeAndParse("git merge-base $currentBranch $parentBranch")
-            .firstOrNull()
-            ?.split(" ")
-            ?.firstOrNull()
+        return commandRunner.executeAndParseFirst("git merge-base $currentBranch $parentBranch")
     }
 
     companion object {

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/ForkCommit.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/ForkCommit.kt
@@ -7,10 +7,6 @@ class ForkCommit: CommitShaProvider {
     override fun getCommitSha(commandRunner: GitClient.CommandRunner): Sha {
         val currentBranch = commandRunner.executeAndParseFirst(CURRENT_BRANCH_CMD)
 
-        requireNotNull(currentBranch) {
-            "Current branch not found"
-        }
-
         val parentBranch = commandRunner.executeAndParse(SHOW_ALL_BRANCHES_CMD)
             .first { !it.contains(currentBranch) && it.contains("*") }
             .substringAfter("[")

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/PreviousCommit.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/PreviousCommit.kt
@@ -4,7 +4,7 @@ import com.dropbox.affectedmoduledetector.GitClient
 import com.dropbox.affectedmoduledetector.Sha
 
 class PreviousCommit: CommitShaProvider {
-    override fun getCommitSha(commandRunner: GitClient.CommandRunner): Sha {
+    override fun get(commandRunner: GitClient.CommandRunner): Sha {
         return commandRunner.executeAndParseFirst(PREV_COMMIT_CMD)
     }
     companion object {

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/PreviousCommit.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/PreviousCommit.kt
@@ -4,11 +4,8 @@ import com.dropbox.affectedmoduledetector.GitClient
 import com.dropbox.affectedmoduledetector.Sha
 
 class PreviousCommit: CommitShaProvider {
-    override fun getCommitSha(commandRunner: GitClient.CommandRunner): Sha? {
-        return commandRunner.executeAndParse(PREV_COMMIT_CMD)
-            .firstOrNull()
-            ?.split(" ")
-            ?.firstOrNull()
+    override fun getCommitSha(commandRunner: GitClient.CommandRunner): Sha {
+        return commandRunner.executeAndParseFirst(PREV_COMMIT_CMD)
     }
     companion object {
         const val PREV_COMMIT_CMD = "git --no-pager rev-parse HEAD~1"

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/PreviousCommit.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/PreviousCommit.kt
@@ -1,0 +1,16 @@
+package com.dropbox.affectedmoduledetector.commitshaproviders
+
+import com.dropbox.affectedmoduledetector.GitClient
+import com.dropbox.affectedmoduledetector.Sha
+
+class PreviousCommit: CommitShaProvider {
+    override fun getCommitSha(commandRunner: GitClient.CommandRunner): Sha? {
+        return commandRunner.executeAndParse(PREV_COMMIT_CMD)
+            .firstOrNull()
+            ?.split(" ")
+            ?.firstOrNull()
+    }
+    companion object {
+        const val PREV_COMMIT_CMD = "git --no-pager rev-parse HEAD~1"
+    }
+}

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleConfigurationTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleConfigurationTest.kt
@@ -9,6 +9,7 @@ import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import java.io.File
+import java.lang.Exception
 
 @RunWith(JUnit4::class)
 class AffectedModuleConfigurationTest {
@@ -159,4 +160,31 @@ class AffectedModuleConfigurationTest {
         assertThat(AffectedModuleConfiguration.name).isEqualTo("affectedModuleDetector")
     }
 
+    @Test
+    fun `GIVEN AffectedModuleConfiguration WHEN compareFrom THEN is PreviousCommit`() {
+        val actual = config.compareFrom
+
+        assertThat(actual).isEqualTo("PreviousCommit")
+    }
+
+    @Test
+    fun `GIVEN AffectedModuleConfiguration WHEN compareFrom is set to ForkCommit THEN is ForkCommit`() {
+        val forkCommit = "ForkCommit"
+
+        config.compareFrom = forkCommit
+
+        val actual = config.compareFrom
+        assertThat(actual).isEqualTo(forkCommit)
+    }
+
+    @Test
+    fun `GIVEN AffectedModuleConfiguration WHEN compareFrom is set to invalid sha provider THEN exception thrown and value not set`() {
+        try {
+            config.compareFrom = "InvalidInput"
+            fail()
+        } catch (e: Exception) {
+            assertThat(e::class).isEqualTo(IllegalArgumentException::class)
+            assertThat(e.message).isEqualTo("The property configuration compareFrom must be one of the following: PreviousCommit, ForkCommit")
+        }
+    }
 }

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleConfigurationTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleConfigurationTest.kt
@@ -1,7 +1,7 @@
 package com.dropbox.affectedmoduledetector
 
 import com.google.common.truth.Truth.assertThat
-import junit.framework.Assert.fail
+import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleConfigurationTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleConfigurationTest.kt
@@ -185,6 +185,7 @@ class AffectedModuleConfigurationTest {
         } catch (e: Exception) {
             assertThat(e::class).isEqualTo(IllegalArgumentException::class)
             assertThat(e.message).isEqualTo("The property configuration compareFrom must be one of the following: PreviousCommit, ForkCommit")
+            assertThat(config.compareFrom).isEqualTo("PreviousCommit")
         }
     }
 }

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorImplTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorImplTest.kt
@@ -1241,7 +1241,6 @@ class AffectedModuleDetectorImplTest {
     ) : GitClient {
 
         override fun findChangedFiles(
-            top: Sha,
             includeUncommitted: Boolean
         ) = changedFiles
 

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorImplTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorImplTest.kt
@@ -1241,6 +1241,7 @@ class AffectedModuleDetectorImplTest {
     ) : GitClient {
 
         override fun findChangedFiles(
+            top: Sha,
             includeUncommitted: Boolean
         ) = changedFiles
 

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorImplTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorImplTest.kt
@@ -178,7 +178,6 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
                 changedFiles = emptyList(),
                 tmpFolder = tmpFolder.root
             ),
@@ -200,7 +199,6 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.DEPENDENT_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
                 changedFiles = emptyList(),
                 tmpFolder = tmpFolder.root
             ),
@@ -222,7 +220,6 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.CHANGED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
                 changedFiles = emptyList(),
                 tmpFolder = tmpFolder.root
             ),
@@ -244,7 +241,6 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
                 changedFiles = listOf(convertToFilePath("p1", "foo.java")),
                 tmpFolder = tmpFolder.root
             ),
@@ -266,7 +262,6 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.DEPENDENT_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
                 changedFiles = listOf(convertToFilePath("p1", "foo.java")),
                 tmpFolder = tmpFolder.root
             ),
@@ -288,7 +283,6 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.CHANGED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
                 changedFiles = listOf(convertToFilePath("p1", "foo.java")),
                 tmpFolder = tmpFolder.root
             ),
@@ -310,7 +304,6 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath("p1", "foo.java"),
                     convertToFilePath("p2", "bar.java")
@@ -335,7 +328,6 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.DEPENDENT_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath("p1", "foo.java"),
                     convertToFilePath("p2", "bar.java")
@@ -360,7 +352,6 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.CHANGED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath("p1", "foo.java"),
                     convertToFilePath("p2", "bar.java")
@@ -385,7 +376,6 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.CHANGED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
                 changedFiles = listOf("foo.java"),
                 tmpFolder = tmpFolder.root
             ),
@@ -407,7 +397,6 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.CHANGED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
                 changedFiles = listOf("foo.java"),
                 tmpFolder = tmpFolder.root
             ),
@@ -429,7 +418,6 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.CHANGED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
                 changedFiles = listOf("foo.java", convertToFilePath("p7", "bar.java")),
                 tmpFolder = tmpFolder.root
             ),
@@ -451,7 +439,6 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath(
                         "compose", "foo.java"
@@ -477,7 +464,6 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.CHANGED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath(
                         "compose", "foo.java"
@@ -503,7 +489,6 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.DEPENDENT_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath(
                         "compose", "foo.java"
@@ -529,7 +514,6 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath(
                         "compose", "foo.java"
@@ -555,7 +539,6 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.CHANGED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath(
                         "compose", "foo.java"
@@ -581,7 +564,6 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.DEPENDENT_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath(
                         "compose", "foo.java"
@@ -607,7 +589,6 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath(
                         "p8", "foo.java"
@@ -633,7 +614,6 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.CHANGED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath(
                         "p8", "foo.java"
@@ -658,7 +638,6 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.DEPENDENT_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath(
                         "p8", "foo.java"
@@ -684,7 +663,6 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath(
                         "p8", "foo.java"
@@ -710,7 +688,6 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath("p7", "foo.java"),
                     convertToFilePath("compose", "foo.java")
@@ -735,7 +712,6 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.CHANGED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath("p7", "foo.java"),
                     convertToFilePath("compose", "foo.java")
@@ -760,7 +736,6 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.DEPENDENT_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath("p7", "foo.java"),
                     convertToFilePath("compose", "foo.java")
@@ -785,7 +760,6 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath("p7", "foo.java"),
                     convertToFilePath("compose", "foo.java")
@@ -810,7 +784,6 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.CHANGED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath("p7", "foo.java"),
                     convertToFilePath("compose", "foo.java")
@@ -835,7 +808,6 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.DEPENDENT_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath("p7", "foo.java"),
                     convertToFilePath("compose", "foo.java")
@@ -860,7 +832,6 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath("..", "gradle.properties")
                 ),
@@ -884,7 +855,6 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath("gradle.properties")
                 ),
@@ -908,7 +878,6 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath("tools", "android", "buildSrc", "foo.java")
                 ),
@@ -932,7 +901,6 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath("tools", "android", "buildSrc", "foo.java")
                 ),
@@ -957,7 +925,6 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath("ui", "gradlew")
                 ),
@@ -981,7 +948,6 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath("android", "gradlew")
                 ),
@@ -1005,7 +971,6 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath("tools", "android", "buildSrc", "foo.sh")
                 ),
@@ -1029,7 +994,6 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
                 changedFiles = listOf(convertToFilePath("tools", "android", "buildSrc", "sample.thing?")),
                 tmpFolder = tmpFolder.root
             ),
@@ -1051,7 +1015,6 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.CHANGED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
                 changedFiles = listOf(convertToFilePath("p1", "foo.java")),
                 tmpFolder = tmpFolder.root
             ),
@@ -1095,7 +1058,6 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.DEPENDENT_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
                 changedFiles = listOf(convertToFilePath("p1", "foo.java")),
                 tmpFolder = tmpFolder.root
             ),
@@ -1139,7 +1101,6 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
                 changedFiles = listOf(convertToFilePath("p1", "foo.java")),
                 tmpFolder = tmpFolder.root
             ),
@@ -1219,7 +1180,6 @@ class AffectedModuleDetectorImplTest {
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             modules = setOf(":p1"),
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
                 changedFiles = listOf(convertToFilePath("p1", "foo.java")),
                 tmpFolder = tmpFolder.root
             ),
@@ -1239,7 +1199,6 @@ class AffectedModuleDetectorImplTest {
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             modules = emptySet(),
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
                 changedFiles = listOf(convertToFilePath("p1", "foo.java")),
                 tmpFolder = tmpFolder.root
             ),
@@ -1260,7 +1219,6 @@ class AffectedModuleDetectorImplTest {
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             modules = null,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
                 changedFiles = listOf(convertToFilePath("p1", "foo.java")),
                 tmpFolder = tmpFolder.root
             ),
@@ -1278,18 +1236,14 @@ class AffectedModuleDetectorImplTest {
     }
 
     private class MockGitClient(
-        val lastMergeSha: String?,
         val changedFiles: List<String>,
         val tmpFolder: File
     ) : GitClient {
 
-        override fun findChangedFilesSince(
-            sha: String,
-            top: String,
+        override fun findChangedFiles(
+            top: Sha,
             includeUncommitted: Boolean
         ) = changedFiles
-
-        override fun findPreviousCommitSha() = lastMergeSha
 
         override fun getGitRoot(): File {
             return tmpFolder

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorImplTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorImplTest.kt
@@ -178,7 +178,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMasterCommitSha = "foo",
+                lastMergeSha = "foo",
                 changedFiles = emptyList(),
                 tmpFolder = tmpFolder.root
             ),
@@ -200,7 +200,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.DEPENDENT_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMasterCommitSha = "foo",
+                lastMergeSha = "foo",
                 changedFiles = emptyList(),
                 tmpFolder = tmpFolder.root
             ),
@@ -222,7 +222,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.CHANGED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMasterCommitSha = "foo",
+                lastMergeSha = "foo",
                 changedFiles = emptyList(),
                 tmpFolder = tmpFolder.root
             ),
@@ -244,7 +244,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMasterCommitSha = "foo",
+                lastMergeSha = "foo",
                 changedFiles = listOf(convertToFilePath("p1", "foo.java")),
                 tmpFolder = tmpFolder.root
             ),
@@ -266,7 +266,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.DEPENDENT_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMasterCommitSha = "foo",
+                lastMergeSha = "foo",
                 changedFiles = listOf(convertToFilePath("p1", "foo.java")),
                 tmpFolder = tmpFolder.root
             ),
@@ -288,7 +288,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.CHANGED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMasterCommitSha = "foo",
+                lastMergeSha = "foo",
                 changedFiles = listOf(convertToFilePath("p1", "foo.java")),
                 tmpFolder = tmpFolder.root
             ),
@@ -310,7 +310,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMasterCommitSha = "foo",
+                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath("p1", "foo.java"),
                     convertToFilePath("p2", "bar.java")
@@ -335,7 +335,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.DEPENDENT_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMasterCommitSha = "foo",
+                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath("p1", "foo.java"),
                     convertToFilePath("p2", "bar.java")
@@ -360,7 +360,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.CHANGED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMasterCommitSha = "foo",
+                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath("p1", "foo.java"),
                     convertToFilePath("p2", "bar.java")
@@ -385,7 +385,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.CHANGED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMasterCommitSha = "foo",
+                lastMergeSha = "foo",
                 changedFiles = listOf("foo.java"),
                 tmpFolder = tmpFolder.root
             ),
@@ -407,7 +407,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.CHANGED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMasterCommitSha = "foo",
+                lastMergeSha = "foo",
                 changedFiles = listOf("foo.java"),
                 tmpFolder = tmpFolder.root
             ),
@@ -429,7 +429,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.CHANGED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMasterCommitSha = "foo",
+                lastMergeSha = "foo",
                 changedFiles = listOf("foo.java", convertToFilePath("p7", "bar.java")),
                 tmpFolder = tmpFolder.root
             ),
@@ -451,7 +451,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMasterCommitSha = "foo",
+                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath(
                         "compose", "foo.java"
@@ -477,7 +477,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.CHANGED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMasterCommitSha = "foo",
+                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath(
                         "compose", "foo.java"
@@ -503,7 +503,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.DEPENDENT_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMasterCommitSha = "foo",
+                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath(
                         "compose", "foo.java"
@@ -529,7 +529,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMasterCommitSha = "foo",
+                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath(
                         "compose", "foo.java"
@@ -555,7 +555,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.CHANGED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMasterCommitSha = "foo",
+                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath(
                         "compose", "foo.java"
@@ -581,7 +581,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.DEPENDENT_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMasterCommitSha = "foo",
+                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath(
                         "compose", "foo.java"
@@ -607,7 +607,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMasterCommitSha = "foo",
+                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath(
                         "p8", "foo.java"
@@ -633,7 +633,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.CHANGED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMasterCommitSha = "foo",
+                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath(
                         "p8", "foo.java"
@@ -658,7 +658,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.DEPENDENT_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMasterCommitSha = "foo",
+                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath(
                         "p8", "foo.java"
@@ -684,7 +684,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMasterCommitSha = "foo",
+                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath(
                         "p8", "foo.java"
@@ -710,7 +710,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMasterCommitSha = "foo",
+                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath("p7", "foo.java"),
                     convertToFilePath("compose", "foo.java")
@@ -735,7 +735,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.CHANGED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMasterCommitSha = "foo",
+                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath("p7", "foo.java"),
                     convertToFilePath("compose", "foo.java")
@@ -760,7 +760,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.DEPENDENT_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMasterCommitSha = "foo",
+                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath("p7", "foo.java"),
                     convertToFilePath("compose", "foo.java")
@@ -785,7 +785,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMasterCommitSha = "foo",
+                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath("p7", "foo.java"),
                     convertToFilePath("compose", "foo.java")
@@ -810,7 +810,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.CHANGED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMasterCommitSha = "foo",
+                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath("p7", "foo.java"),
                     convertToFilePath("compose", "foo.java")
@@ -835,7 +835,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.DEPENDENT_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMasterCommitSha = "foo",
+                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath("p7", "foo.java"),
                     convertToFilePath("compose", "foo.java")
@@ -860,7 +860,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMasterCommitSha = "foo",
+                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath("..", "gradle.properties")
                 ),
@@ -884,7 +884,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMasterCommitSha = "foo",
+                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath("gradle.properties")
                 ),
@@ -908,7 +908,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMasterCommitSha = "foo",
+                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath("tools", "android", "buildSrc", "foo.java")
                 ),
@@ -932,7 +932,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMasterCommitSha = "foo",
+                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath("tools", "android", "buildSrc", "foo.java")
                 ),
@@ -957,7 +957,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMasterCommitSha = "foo",
+                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath("ui", "gradlew")
                 ),
@@ -981,7 +981,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMasterCommitSha = "foo",
+                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath("android", "gradlew")
                 ),
@@ -1005,7 +1005,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMasterCommitSha = "foo",
+                lastMergeSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath("tools", "android", "buildSrc", "foo.sh")
                 ),
@@ -1029,7 +1029,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMasterCommitSha = "foo",
+                lastMergeSha = "foo",
                 changedFiles = listOf(convertToFilePath("tools", "android", "buildSrc", "sample.thing?")),
                 tmpFolder = tmpFolder.root
             ),
@@ -1051,7 +1051,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.CHANGED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMasterCommitSha = "foo",
+                lastMergeSha = "foo",
                 changedFiles = listOf(convertToFilePath("p1", "foo.java")),
                 tmpFolder = tmpFolder.root
             ),
@@ -1095,7 +1095,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.DEPENDENT_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMasterCommitSha = "foo",
+                lastMergeSha = "foo",
                 changedFiles = listOf(convertToFilePath("p1", "foo.java")),
                 tmpFolder = tmpFolder.root
             ),
@@ -1139,7 +1139,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMasterCommitSha = "foo",
+                lastMergeSha = "foo",
                 changedFiles = listOf(convertToFilePath("p1", "foo.java")),
                 tmpFolder = tmpFolder.root
             ),
@@ -1219,7 +1219,7 @@ class AffectedModuleDetectorImplTest {
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             modules = setOf(":p1"),
             injectedGitClient = MockGitClient(
-                lastMasterCommitSha = "foo",
+                lastMergeSha = "foo",
                 changedFiles = listOf(convertToFilePath("p1", "foo.java")),
                 tmpFolder = tmpFolder.root
             ),
@@ -1239,7 +1239,7 @@ class AffectedModuleDetectorImplTest {
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             modules = emptySet(),
             injectedGitClient = MockGitClient(
-                lastMasterCommitSha = "foo",
+                lastMergeSha = "foo",
                 changedFiles = listOf(convertToFilePath("p1", "foo.java")),
                 tmpFolder = tmpFolder.root
             ),
@@ -1260,7 +1260,7 @@ class AffectedModuleDetectorImplTest {
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             modules = null,
             injectedGitClient = MockGitClient(
-                lastMasterCommitSha = "foo",
+                lastMergeSha = "foo",
                 changedFiles = listOf(convertToFilePath("p1", "foo.java")),
                 tmpFolder = tmpFolder.root
             ),
@@ -1278,7 +1278,7 @@ class AffectedModuleDetectorImplTest {
     }
 
     private class MockGitClient(
-        val lastMasterCommitSha: String?,
+        val lastMergeSha: String?,
         val changedFiles: List<String>,
         val tmpFolder: File
     ) : GitClient {
@@ -1289,7 +1289,7 @@ class AffectedModuleDetectorImplTest {
             includeUncommitted: Boolean
         ) = changedFiles
 
-        override fun findLastMasterCommit() = lastMasterCommitSha
+        override fun findPreviousCommitSha() = lastMergeSha
 
         override fun getGitRoot(): File {
             return tmpFolder

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorImplTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorImplTest.kt
@@ -178,7 +178,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
+                lastMasterCommitSha = "foo",
                 changedFiles = emptyList(),
                 tmpFolder = tmpFolder.root
             ),
@@ -200,7 +200,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.DEPENDENT_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
+                lastMasterCommitSha = "foo",
                 changedFiles = emptyList(),
                 tmpFolder = tmpFolder.root
             ),
@@ -222,7 +222,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.CHANGED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
+                lastMasterCommitSha = "foo",
                 changedFiles = emptyList(),
                 tmpFolder = tmpFolder.root
             ),
@@ -244,7 +244,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
+                lastMasterCommitSha = "foo",
                 changedFiles = listOf(convertToFilePath("p1", "foo.java")),
                 tmpFolder = tmpFolder.root
             ),
@@ -266,7 +266,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.DEPENDENT_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
+                lastMasterCommitSha = "foo",
                 changedFiles = listOf(convertToFilePath("p1", "foo.java")),
                 tmpFolder = tmpFolder.root
             ),
@@ -288,7 +288,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.CHANGED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
+                lastMasterCommitSha = "foo",
                 changedFiles = listOf(convertToFilePath("p1", "foo.java")),
                 tmpFolder = tmpFolder.root
             ),
@@ -310,7 +310,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
+                lastMasterCommitSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath("p1", "foo.java"),
                     convertToFilePath("p2", "bar.java")
@@ -335,7 +335,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.DEPENDENT_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
+                lastMasterCommitSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath("p1", "foo.java"),
                     convertToFilePath("p2", "bar.java")
@@ -360,7 +360,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.CHANGED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
+                lastMasterCommitSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath("p1", "foo.java"),
                     convertToFilePath("p2", "bar.java")
@@ -385,7 +385,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.CHANGED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
+                lastMasterCommitSha = "foo",
                 changedFiles = listOf("foo.java"),
                 tmpFolder = tmpFolder.root
             ),
@@ -407,7 +407,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.CHANGED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
+                lastMasterCommitSha = "foo",
                 changedFiles = listOf("foo.java"),
                 tmpFolder = tmpFolder.root
             ),
@@ -429,7 +429,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.CHANGED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
+                lastMasterCommitSha = "foo",
                 changedFiles = listOf("foo.java", convertToFilePath("p7", "bar.java")),
                 tmpFolder = tmpFolder.root
             ),
@@ -451,7 +451,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
+                lastMasterCommitSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath(
                         "compose", "foo.java"
@@ -477,7 +477,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.CHANGED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
+                lastMasterCommitSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath(
                         "compose", "foo.java"
@@ -503,7 +503,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.DEPENDENT_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
+                lastMasterCommitSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath(
                         "compose", "foo.java"
@@ -529,7 +529,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
+                lastMasterCommitSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath(
                         "compose", "foo.java"
@@ -555,7 +555,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.CHANGED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
+                lastMasterCommitSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath(
                         "compose", "foo.java"
@@ -581,7 +581,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.DEPENDENT_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
+                lastMasterCommitSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath(
                         "compose", "foo.java"
@@ -607,7 +607,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
+                lastMasterCommitSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath(
                         "p8", "foo.java"
@@ -633,7 +633,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.CHANGED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
+                lastMasterCommitSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath(
                         "p8", "foo.java"
@@ -658,7 +658,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.DEPENDENT_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
+                lastMasterCommitSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath(
                         "p8", "foo.java"
@@ -684,7 +684,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
+                lastMasterCommitSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath(
                         "p8", "foo.java"
@@ -710,7 +710,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
+                lastMasterCommitSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath("p7", "foo.java"),
                     convertToFilePath("compose", "foo.java")
@@ -735,7 +735,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.CHANGED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
+                lastMasterCommitSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath("p7", "foo.java"),
                     convertToFilePath("compose", "foo.java")
@@ -760,7 +760,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.DEPENDENT_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
+                lastMasterCommitSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath("p7", "foo.java"),
                     convertToFilePath("compose", "foo.java")
@@ -785,7 +785,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
+                lastMasterCommitSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath("p7", "foo.java"),
                     convertToFilePath("compose", "foo.java")
@@ -810,7 +810,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.CHANGED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
+                lastMasterCommitSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath("p7", "foo.java"),
                     convertToFilePath("compose", "foo.java")
@@ -835,7 +835,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.DEPENDENT_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
+                lastMasterCommitSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath("p7", "foo.java"),
                     convertToFilePath("compose", "foo.java")
@@ -860,7 +860,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
+                lastMasterCommitSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath("..", "gradle.properties")
                 ),
@@ -884,7 +884,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
+                lastMasterCommitSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath("gradle.properties")
                 ),
@@ -908,7 +908,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
+                lastMasterCommitSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath("tools", "android", "buildSrc", "foo.java")
                 ),
@@ -932,7 +932,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
+                lastMasterCommitSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath("tools", "android", "buildSrc", "foo.java")
                 ),
@@ -957,7 +957,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
+                lastMasterCommitSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath("ui", "gradlew")
                 ),
@@ -981,7 +981,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
+                lastMasterCommitSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath("android", "gradlew")
                 ),
@@ -1005,7 +1005,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
+                lastMasterCommitSha = "foo",
                 changedFiles = listOf(
                     convertToFilePath("tools", "android", "buildSrc", "foo.sh")
                 ),
@@ -1029,7 +1029,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
+                lastMasterCommitSha = "foo",
                 changedFiles = listOf(convertToFilePath("tools", "android", "buildSrc", "sample.thing?")),
                 tmpFolder = tmpFolder.root
             ),
@@ -1051,7 +1051,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.CHANGED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
+                lastMasterCommitSha = "foo",
                 changedFiles = listOf(convertToFilePath("p1", "foo.java")),
                 tmpFolder = tmpFolder.root
             ),
@@ -1095,7 +1095,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.DEPENDENT_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
+                lastMasterCommitSha = "foo",
                 changedFiles = listOf(convertToFilePath("p1", "foo.java")),
                 tmpFolder = tmpFolder.root
             ),
@@ -1139,7 +1139,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
+                lastMasterCommitSha = "foo",
                 changedFiles = listOf(convertToFilePath("p1", "foo.java")),
                 tmpFolder = tmpFolder.root
             ),
@@ -1219,7 +1219,7 @@ class AffectedModuleDetectorImplTest {
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             modules = setOf(":p1"),
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
+                lastMasterCommitSha = "foo",
                 changedFiles = listOf(convertToFilePath("p1", "foo.java")),
                 tmpFolder = tmpFolder.root
             ),
@@ -1239,7 +1239,7 @@ class AffectedModuleDetectorImplTest {
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             modules = emptySet(),
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
+                lastMasterCommitSha = "foo",
                 changedFiles = listOf(convertToFilePath("p1", "foo.java")),
                 tmpFolder = tmpFolder.root
             ),
@@ -1260,7 +1260,7 @@ class AffectedModuleDetectorImplTest {
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             modules = null,
             injectedGitClient = MockGitClient(
-                lastMergeSha = "foo",
+                lastMasterCommitSha = "foo",
                 changedFiles = listOf(convertToFilePath("p1", "foo.java")),
                 tmpFolder = tmpFolder.root
             ),
@@ -1278,7 +1278,7 @@ class AffectedModuleDetectorImplTest {
     }
 
     private class MockGitClient(
-        val lastMergeSha: String?,
+        val lastMasterCommitSha: String?,
         val changedFiles: List<String>,
         val tmpFolder: File
     ) : GitClient {
@@ -1289,7 +1289,7 @@ class AffectedModuleDetectorImplTest {
             includeUncommitted: Boolean
         ) = changedFiles
 
-        override fun findPreviousCommitSha() = lastMergeSha
+        override fun findLastMasterCommit() = lastMasterCommitSha
 
         override fun getGitRoot(): File {
             return tmpFolder

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/GitClientImplTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/GitClientImplTest.kt
@@ -68,6 +68,7 @@ class GitClientImplTest {
         assertEquals(
                 changes,
                 client.findChangedFiles(
+                    top = "otherSha",
                     includeUncommitted = false
                 ))
     }

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/GitClientImplTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/GitClientImplTest.kt
@@ -7,6 +7,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import com.dropbox.affectedmoduledetector.GitClientImpl.Companion.CHANGED_FILES_CMD_PREFIX
+import com.dropbox.affectedmoduledetector.mocks.MockCommandRunner
+import com.dropbox.affectedmoduledetector.mocks.MockCommitShaProvider
 
 @RunWith(JUnit4::class)
 class GitClientImplTest {
@@ -20,75 +22,59 @@ class GitClientImplTest {
      * directory somewhere in the parent directory tree.  @see [GitClientImpl]
      */
     private val workingDir = File(System.getProperty("user.dir")).parentFile
+    private val commitShaProvider = MockCommitShaProvider()
     private val client = GitClientImpl(
         workingDir = workingDir,
         logger = logger,
-        commandRunner = commandRunner
+        commandRunner = commandRunner,
+        commitShaProvider = commitShaProvider
     )
 
-
     @Test
-    fun findChangesSince() {
-        var changes = listOf(
+    fun givenChangedFiles_whenFindChangedFilesIncludeUncommitted_thenReturnChanges() {
+        val changes = listOf(
                 convertToFilePath("a", "b", "c.java"),
                 convertToFilePath("d", "e", "f.java"))
         commandRunner.addReply(
                 "$CHANGED_FILES_CMD_PREFIX HEAD..mySha",
                 changes.joinToString(System.lineSeparator())
         )
+        commitShaProvider.addReply("mySha")
+
         assertEquals(
                 changes,
-                client.findChangedFilesSince(sha = "mySha", includeUncommitted = true))
+                client.findChangedFiles(includeUncommitted = true))
     }
 
     @Test
     fun findChangesSince_empty() {
+        commitShaProvider.addReply("mySha")
         assertEquals(
                 emptyList<String>(),
-                client.findChangedFilesSince("foo"))
+                client.findChangedFiles()
+        )
     }
 
     @Test
     fun findChangesSince_twoCls() {
-        var changes = listOf(
+        val changes = listOf(
                 convertToFilePath("a", "b", "c.java"),
                 convertToFilePath("d", "e", "f.java"))
         commandRunner.addReply(
                 "$CHANGED_FILES_CMD_PREFIX otherSha mySha",
                 changes.joinToString(System.lineSeparator())
         )
+        commitShaProvider.addReply("mySha")
         assertEquals(
                 changes,
-                client.findChangedFilesSince(
-                        sha = "mySha",
-                        top = "otherSha",
-                        includeUncommitted = false))
+                client.findChangedFiles(
+                    top = "otherSha",
+                    includeUncommitted = false
+                ))
     }
 
     // For both Linux/Windows
     fun convertToFilePath(vararg list: String): String {
         return list.toList().joinToString(File.separator)
-    }
-
-    private class MockCommandRunner(val logger: ToStringLogger) : GitClient.CommandRunner {
-        private val replies = mutableMapOf<String, List<String>>()
-
-        fun addReply(command: String, response: String) {
-            logger.info("add reply. cmd: $command response: $response")
-            replies[command] = response.split(System.lineSeparator())
-        }
-
-        override fun execute(command: String): String {
-            return replies.getOrDefault(command, emptyList())
-                .joinToString(System.lineSeparator()).also {
-                    logger.info("cmd: $command response: $it")
-            }
-        }
-
-        override fun executeAndParse(command: String): List<String> {
-            return replies.getOrDefault(command, emptyList()).also {
-                logger.info("cmd: $command response: $it")
-            }
-        }
     }
 }

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/GitClientImplTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/GitClientImplTest.kt
@@ -68,7 +68,6 @@ class GitClientImplTest {
         assertEquals(
                 changes,
                 client.findChangedFiles(
-                    top = "otherSha",
                     includeUncommitted = false
                 ))
     }

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/CommitShaProviderTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/CommitShaProviderTest.kt
@@ -4,6 +4,8 @@ import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
+import java.lang.IllegalArgumentException
+import org.junit.Assert.fail
 
 @RunWith(JUnit4::class)
 class CommitShaProviderTest {
@@ -19,5 +21,16 @@ class CommitShaProviderTest {
         val actual = CommitShaProvider.fromString("ForkCommit")
 
         assertThat(actual::class).isEqualTo(ForkCommit::class)
+    }
+
+    @Test
+    fun givenInvalidCommitString_whenFromString_thenExceptionThrown() {
+        try {
+            CommitShaProvider.fromString("Invalid")
+            fail()
+        } catch (e: Exception) {
+            assertThat(e::class).isEqualTo(IllegalArgumentException::class)
+            assertThat(e.message).isEqualTo("Unsupported compareFrom type")
+        }
     }
 }

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/CommitShaProviderTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/CommitShaProviderTest.kt
@@ -1,0 +1,23 @@
+package com.dropbox.affectedmoduledetector.commitshaproviders
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class CommitShaProviderTest {
+    @Test
+    fun givenPreviousCommit_whenFromString_thenReturnPreviousCommit() {
+        val actual = CommitShaProvider.fromString("PreviousCommit")
+
+        assertThat(actual::class).isEqualTo(PreviousCommit::class)
+    }
+
+    @Test
+    fun givenForkCommit_whenFromString_thenReturnPreviousCommit() {
+        val actual = CommitShaProvider.fromString("ForkCommit")
+
+        assertThat(actual::class).isEqualTo(ForkCommit::class)
+    }
+}

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/ForkCommitTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/ForkCommitTest.kt
@@ -33,7 +33,7 @@ class ForkCommitTest {
         val parentBranches = listOf("[main]")
         commandRunner.addReply(ForkCommit.SHOW_ALL_BRANCHES_CMD, parentBranches.joinToString(System.lineSeparator()))
 
-        forkCommit.getCommitSha(commandRunner)
+        forkCommit.get(commandRunner)
     }
 
     @Test(expected = IllegalArgumentException::class)
@@ -42,7 +42,7 @@ class ForkCommitTest {
         val parentBranches = listOf("[main]")
         commandRunner.addReply(ForkCommit.SHOW_ALL_BRANCHES_CMD, parentBranches.joinToString(System.lineSeparator()))
 
-        forkCommit.getCommitSha(commandRunner)
+        forkCommit.get(commandRunner)
     }
 
     @Test
@@ -52,7 +52,7 @@ class ForkCommitTest {
         commandRunner.addReply(ForkCommit.SHOW_ALL_BRANCHES_CMD, parentBranches.joinToString(System.lineSeparator()))
         commandRunner.addReply("git merge-base feature main", "commit-sha")
 
-        val actual = forkCommit.getCommitSha(commandRunner)
+        val actual = forkCommit.get(commandRunner)
 
         assertThat(actual).isEqualTo("commit-sha")
     }

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/ForkCommitTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/ForkCommitTest.kt
@@ -1,0 +1,59 @@
+package com.dropbox.affectedmoduledetector.commitshaproviders
+
+import com.dropbox.affectedmoduledetector.AttachLogsTestRule
+import com.dropbox.affectedmoduledetector.mocks.MockCommandRunner
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class ForkCommitTest {
+    @Rule
+    @JvmField
+    val attachLogsRule = AttachLogsTestRule()
+    private val logger = attachLogsRule.logger
+    private val commandRunner = MockCommandRunner(logger)
+    private val forkCommit = ForkCommit()
+
+    @Test
+    fun whenCURRENT_BRANCH_CMD_thenCommandReturned() {
+        assertThat(ForkCommit.CURRENT_BRANCH_CMD).isEqualTo("git rev-parse --abbrev-ref HEAD")
+    }
+
+    @Test
+    fun whenSHOW_ALL_BRANCHES_CMD_thenCommandReturned() {
+        assertThat(ForkCommit.SHOW_ALL_BRANCHES_CMD).isEqualTo("git show-branch -a")
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun givenNoParentBranchThatIsNotCurrentBranch_whenGetCommitSha_thenThrowException() {
+        commandRunner.addReply(ForkCommit.CURRENT_BRANCH_CMD, "main")
+        val parentBranches = listOf("[main]")
+        commandRunner.addReply(ForkCommit.SHOW_ALL_BRANCHES_CMD, parentBranches.joinToString(System.lineSeparator()))
+
+        forkCommit.getCommitSha(commandRunner)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun givenNoParentBranchThatContainsAsterisk_whenGetCommitSha_thenThrowException() {
+        commandRunner.addReply(ForkCommit.CURRENT_BRANCH_CMD, "feature")
+        val parentBranches = listOf("[main]")
+        commandRunner.addReply(ForkCommit.SHOW_ALL_BRANCHES_CMD, parentBranches.joinToString(System.lineSeparator()))
+
+        forkCommit.getCommitSha(commandRunner)
+    }
+
+    @Test
+    fun givenParentBranchWithSymbols_whenGetCommitSha_thenReturnForkCommitSha() {
+        commandRunner.addReply(ForkCommit.CURRENT_BRANCH_CMD, "feature")
+        val parentBranches = listOf("* [main^~SNAPSHOT_01]")
+        commandRunner.addReply(ForkCommit.SHOW_ALL_BRANCHES_CMD, parentBranches.joinToString(System.lineSeparator()))
+        commandRunner.addReply("git merge-base feature main", "commit-sha")
+
+        val actual = forkCommit.getCommitSha(commandRunner)
+
+        assertThat(actual).isEqualTo("commit-sha")
+    }
+}

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/ForkCommitTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/ForkCommitTest.kt
@@ -3,6 +3,7 @@ package com.dropbox.affectedmoduledetector.commitshaproviders
 import com.dropbox.affectedmoduledetector.AttachLogsTestRule
 import com.dropbox.affectedmoduledetector.mocks.MockCommandRunner
 import com.google.common.truth.Truth.assertThat
+import org.junit.Assert.fail
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -27,22 +28,40 @@ class ForkCommitTest {
         assertThat(ForkCommit.SHOW_ALL_BRANCHES_CMD).isEqualTo("git show-branch -a")
     }
 
-    @Test(expected = IllegalArgumentException::class)
+    @Test
     fun givenNoParentBranchThatIsNotCurrentBranch_whenGetCommitSha_thenThrowException() {
-        commandRunner.addReply(ForkCommit.CURRENT_BRANCH_CMD, "main")
-        val parentBranches = listOf("[main]")
-        commandRunner.addReply(ForkCommit.SHOW_ALL_BRANCHES_CMD, parentBranches.joinToString(System.lineSeparator()))
+        try {
+            commandRunner.addReply(ForkCommit.CURRENT_BRANCH_CMD, "main")
+            val parentBranches = listOf("[main]")
+            commandRunner.addReply(
+                ForkCommit.SHOW_ALL_BRANCHES_CMD,
+                parentBranches.joinToString(System.lineSeparator())
+            )
 
-        forkCommit.get(commandRunner)
+            forkCommit.get(commandRunner)
+            fail()
+        } catch (e: Exception) {
+            assertThat(e::class).isEqualTo(IllegalArgumentException::class)
+            assertThat(e.message).isEqualTo("Parent branch not found")
+        }
     }
 
-    @Test(expected = IllegalArgumentException::class)
+    @Test
     fun givenNoParentBranchThatContainsAsterisk_whenGetCommitSha_thenThrowException() {
-        commandRunner.addReply(ForkCommit.CURRENT_BRANCH_CMD, "feature")
-        val parentBranches = listOf("[main]")
-        commandRunner.addReply(ForkCommit.SHOW_ALL_BRANCHES_CMD, parentBranches.joinToString(System.lineSeparator()))
+        try {
+            commandRunner.addReply(ForkCommit.CURRENT_BRANCH_CMD, "feature")
+            val parentBranches = listOf("[main]")
+            commandRunner.addReply(
+                ForkCommit.SHOW_ALL_BRANCHES_CMD,
+                parentBranches.joinToString(System.lineSeparator())
+            )
 
-        forkCommit.get(commandRunner)
+            forkCommit.get(commandRunner)
+            fail()
+        } catch (e: Exception) {
+            assertThat(e::class).isEqualTo(IllegalArgumentException::class)
+            assertThat(e.message).isEqualTo("Parent branch not found")
+        }
     }
 
     @Test

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/PreviousCommitTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/PreviousCommitTest.kt
@@ -1,0 +1,33 @@
+package com.dropbox.affectedmoduledetector.commitshaproviders
+
+import com.dropbox.affectedmoduledetector.AttachLogsTestRule
+import com.dropbox.affectedmoduledetector.mocks.MockCommandRunner
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class PreviousCommitTest {
+    @Rule
+    @JvmField
+    val attachLogsRule = AttachLogsTestRule()
+    private val logger = attachLogsRule.logger
+    private val commandRunner = MockCommandRunner(logger)
+    private val previousCommit = PreviousCommit()
+
+    @Test
+    fun whenPREV_COMMIT_CMD_thenCommandReturned() {
+        assertThat(PreviousCommit.PREV_COMMIT_CMD).isEqualTo("git --no-pager rev-parse HEAD~1")
+    }
+
+    @Test
+    fun whenGetCommitSha_thenReturnCommitSha() {
+        commandRunner.addReply(PreviousCommit.PREV_COMMIT_CMD, "commit-sha")
+
+        val actual = previousCommit.getCommitSha(commandRunner)
+
+        assertThat(actual).isEqualTo("commit-sha")
+    }
+}

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/PreviousCommitTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/PreviousCommitTest.kt
@@ -26,7 +26,7 @@ class PreviousCommitTest {
     fun whenGetCommitSha_thenReturnCommitSha() {
         commandRunner.addReply(PreviousCommit.PREV_COMMIT_CMD, "commit-sha")
 
-        val actual = previousCommit.getCommitSha(commandRunner)
+        val actual = previousCommit.get(commandRunner)
 
         assertThat(actual).isEqualTo("commit-sha")
     }

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/mocks/MockCommandRunner.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/mocks/MockCommandRunner.kt
@@ -1,0 +1,32 @@
+package com.dropbox.affectedmoduledetector.mocks
+
+import com.dropbox.affectedmoduledetector.GitClient
+import com.dropbox.affectedmoduledetector.ToStringLogger
+
+class MockCommandRunner(private val logger: ToStringLogger) : GitClient.CommandRunner {
+    private val replies = mutableMapOf<String, List<String>>()
+
+    fun addReply(command: String, response: String) {
+        logger.info("add reply. cmd: $command response: $response")
+        replies[command] = response.split(System.lineSeparator())
+    }
+
+    override fun execute(command: String): String {
+        return replies.getOrDefault(command, emptyList())
+            .joinToString(System.lineSeparator()).also {
+                logger.info("cmd: $command response: $it")
+            }
+    }
+
+    override fun executeAndParse(command: String): List<String> {
+        return replies.getOrDefault(command, emptyList()).also {
+            logger.info("cmd: $command response: $it")
+        }
+    }
+
+    override fun executeAndParseFirst(command: String): String {
+        return replies.getOrDefault(command, emptyList()).first().also {
+            logger.info("cmd: $command response: $it")
+        }
+    }
+}

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/mocks/MockCommitShaProvider.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/mocks/MockCommitShaProvider.kt
@@ -1,0 +1,16 @@
+package com.dropbox.affectedmoduledetector.mocks
+
+import com.dropbox.affectedmoduledetector.GitClient
+import com.dropbox.affectedmoduledetector.Sha
+import com.dropbox.affectedmoduledetector.commitshaproviders.CommitShaProvider
+
+class MockCommitShaProvider: CommitShaProvider {
+    private val replies = mutableListOf<Sha>()
+
+    fun addReply(sha: Sha) {
+        replies.add(sha)
+    }
+    override fun getCommitSha(commandRunner: GitClient.CommandRunner): Sha {
+        return replies.first()
+    }
+}

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/mocks/MockCommitShaProvider.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/mocks/MockCommitShaProvider.kt
@@ -10,7 +10,7 @@ class MockCommitShaProvider: CommitShaProvider {
     fun addReply(sha: Sha) {
         replies.add(sha)
     }
-    override fun getCommitSha(commandRunner: GitClient.CommandRunner): Sha {
+    override fun get(commandRunner: GitClient.CommandRunner): Sha {
         return replies.first()
     }
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -25,6 +25,7 @@ affectedModuleDetector {
     pathsAffectingAllModules = [
             "buildSrc/"
     ]
+    compareFrom = "ForkCommit"
 
     logFolder = "${project.rootDir}"
 }


### PR DESCRIPTION
Addresses https://github.com/dropbox/AffectedModuleDetector/issues/4

Adds the ability to compare between the fork point of the current branch.

Added a compareFrom configuration so the user is able to enter the desired behaviour when comparing the current branch changes to either:
- Previous commit
- Fork point commit

I made a `CommitShaProvider` interface which contains a function which takes the `CommandRunner` and returns a `Sha`. I would have preferred to have the `CommitShaProvider` return a single command without the CommandRunner parameter (as suggested [here](https://github.com/dropbox/AffectedModuleDetector/issues/4#issuecomment-747047679)) but nested commands aren't supported by the `ProcessBuilder` (e.g. 
```
git merge-base $(git rev-parse --abbrev-ref HEAD) $(git show-branch -a | grep '\*' | grep -v `git rev-parse --abbrev-ref HEAD` | head -n1 | sed 's/.*\[\(.*\)\].*/\1/' | sed 's/[\^~].*//')
```
) so I opted for the current solution.