### PR TITLE
Fix for comparing with uncommitted changes

### DIFF
--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/GitClient.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/GitClient.kt
@@ -81,7 +81,7 @@ internal class GitClientImpl(
 
         // use this if we don't want local changes
         return commandRunner.executeAndParse(if (includeUncommitted) {
-            "$CHANGED_FILES_CMD_PREFIX HEAD..$sha"
+            "$CHANGED_FILES_CMD_PREFIX $sha"
         } else {
             "$CHANGED_FILES_CMD_PREFIX $top $sha"
         })

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/GitClientImplTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/GitClientImplTest.kt
@@ -36,7 +36,7 @@ class GitClientImplTest {
                 convertToFilePath("a", "b", "c.java"),
                 convertToFilePath("d", "e", "f.java"))
         commandRunner.addReply(
-                "$CHANGED_FILES_CMD_PREFIX HEAD..mySha",
+                "$CHANGED_FILES_CMD_PREFIX mySha",
                 changes.joinToString(System.lineSeparator())
         )
         commitShaProvider.addReply("mySha")


### PR DESCRIPTION
Fixes https://github.com/dropbox/AffectedModuleDetector/issues/47

If you make an uncommitted change and run the command:
```
git --no-pager diff --name-only HEAD..$sha
```
the uncommitted changes wont be displayed.

If you run the command:
```
git --no-pager diff --name-only $sha
```
the uncommitted changes will be shown.

This is because HEAD points to the last commit on the branch, therefore not considering any uncommitted changes made after that point. 