### PR TITLE
Update dead link to AndroidX project in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,4 +147,4 @@ You should see zero tests run. Make a change within one of the modules and commi
 
 ## Notes
 
-Special thanks to the AndroidX for originally developing this project at https://android.googlesource.com/platform/frameworks/support/+/androidx-master-dev/buildSrc/src/main/kotlin/androidx/build/dependencyTracker
+Special thanks to the AndroidX for originally developing this project at https://android.googlesource.com/platform/frameworks/support/+/androidx-main/buildSrc/src/main/kotlin/androidx/build/dependencyTracker


### PR DESCRIPTION
The current AndroidX project link in the README leads to a 404 because the `androidx-master-dev` branch was replaced by `androidx-main` [here](https://android.googlesource.com/platform/frameworks/support/+/c19a44147515bcc4404409e27db5de4e6e9aa73c).

This PR updates the link accordingly.

Fixes https://github.com/dropbox/AffectedModuleDetector/issues/52