### PR TITLE
Ensure pathsAffectingAllBuilds will include any changed files

### DIFF
--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetector.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetector.kt
@@ -358,6 +358,8 @@ class AffectedModuleDetectorImpl constructor(
         findDependentProjects()
     }
 
+    private var changedFiles: MutableSet<String> = mutableSetOf()
+
     private var unknownFiles: MutableSet<String> = mutableSetOf()
 
     override fun shouldInclude(project: Project): Boolean {
@@ -400,8 +402,10 @@ class AffectedModuleDetectorImpl constructor(
      * Also populates the unknownFiles var which is used in findAffectedProjects
      */
     private fun findChangedProjects(): Set<Project> {
-        val changedFiles = git.findChangedFiles(
-            includeUncommitted = true
+        changedFiles.addAll(
+            git.findChangedFiles(
+                includeUncommitted = true
+            )
         )
 
         val changedProjects = mutableSetOf<Project>()
@@ -462,7 +466,7 @@ class AffectedModuleDetectorImpl constructor(
         if (changedProjects.isEmpty() && unknownFiles.isEmpty()) {
             buildAll = true
         }
-        unknownFiles.forEach {
+        changedFiles.forEach {
             if (affectsAllModules(it)) {
                 buildAll = true
             }


### PR DESCRIPTION
The `pathsAffectedAllBuilds` will only look at unknown files to trigger the build, this changed it to look at any of the changed files. 

#64 