### PR TITLE
Fix documentation referencing an unused configuration property

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,12 @@ affectedModuleDetector {
  
  
  
- Modules can specify a configuration block to specify which variant tests to run
+ By default, the Detector will look for `assembleAndroidDebugTest`, `connectedAndroidDebugTest`, and `testDebug`.  Modules can specify a configuration block to specify which variant tests to run:
  ```groovy
- affectedTestConfiguration{
-    variantToTest = "debug" //default is debug
+ affectedTestConfiguration {
+    assembleAndroidTestTask = "assmebleAndroidReleaseTest"
+    runAndroidTestTask = "connectedAndroidReleaseTest"
+    jvmTestTask = "testRelease"
 }
 ```
  

--- a/sample/buildSrc/src/main/kotlin/com/dropbox/sample/tasks/AffectedTasksPlugin.kt
+++ b/sample/buildSrc/src/main/kotlin/com/dropbox/sample/tasks/AffectedTasksPlugin.kt
@@ -11,10 +11,9 @@ import java.util.*
 var TEST_TASK_TO_RUN_EXTENSION = "TestTasks"
 
 open class TestTasks {
-    var variantToTest = "debug"
-    val assembleAndroidTestTask = "assemble${variantToTest.capitalize()}AndroidTest"
-    val runAndroidTestTask = "connected${variantToTest.capitalize()}AndroidTest"
-    val jvmTest = "test${variantToTest.capitalize()}UnitTest"
+    val assembleAndroidTestTask = "assembleDebugAndroidTest"
+    val runAndroidTestTask = "connectedDebugAndroidTest"
+    val jvmTest = "testDebugUnitTest"
     val jvmTestBackup = "test"
 }
 


### PR DESCRIPTION
Fix some documentation that should have been addressed in #44 

Also noted in #95 