### PR TITLE
Fix maven repo readme typo again

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Apply the project to the root `build.gradle`:
 ```groovy
 buildscript {
   repositories {
-    mavenCental()
+    mavenCentral()
   }
   dependencies {
     classpath "com.dropbox.affectedmoduledetector:affectedmoduledetector:<LATEST_VERSION>"


### PR DESCRIPTION
Oops, fix with correct one.

https://docs.gradle.org/current/userguide/declaring_repositories.html#sub:maven_central