### PR TITLE
Add support for toggling if uncommitted code should be included

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ affectedModuleDetector {
     excludedModules = [
         "sample-util"
     ]
+    includeUncommitted = true
+    top = "HEAD"
 }
 ```
 
@@ -85,14 +87,16 @@ affectedModuleDetector {
     - PreviousCommit: compare against the previous commit
     - ForkCommit: compare against the commit the branch was forked from
     - SpecifiedBranchCommit: specify the branch to compare changes against using the `specifiedBranch` configuration before the `compareFrom` configuration
- - `excludedModules` : A list of modules that will be excluded from the build process
- 
- 
- 
+ - `excludedModules`: A list of modules that will be excluded from the build process
+ - `includeUncommitted`: If uncommitted files should be considered affected
+ - `top`: The top of the git log to use. Must be used in combination with configuration `includeUncommitted = false`
+
+
+
  By default, the Detector will look for `assembleAndroidDebugTest`, `connectedAndroidDebugTest`, and `testDebug`.  Modules can specify a configuration block to specify which variant tests to run:
  ```groovy
  affectedTestConfiguration {
-    assembleAndroidTestTask = "assmebleAndroidReleaseTest"
+    assembleAndroidTestTask = "assembleAndroidReleaseTest"
     runAndroidTestTask = "connectedAndroidReleaseTest"
     jvmTestTask = "testRelease"
 }

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleConfiguration.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleConfiguration.kt
@@ -58,6 +58,22 @@ class AffectedModuleConfiguration {
      */
     var excludedModules = emptySet<String>()
 
+    /**
+     * If uncommitted files should be considered affected
+     */
+    var includeUncommitted: Boolean = true
+
+    /**
+     * The top of the git log to use, only used when [includeUncommitted] is false
+     */
+    var top: String = "HEAD"
+        set(value) {
+            require(!includeUncommitted) {
+                "Set includeUncommitted to false to set a custom top"
+            }
+            field = value
+        }
+
     companion object {
         const val name = "affectedModuleDetector"
     }

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetector.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetector.kt
@@ -351,7 +351,7 @@ class AffectedModuleDetectorImpl constructor(
     }
 
     private val changedProjects by lazy {
-        findChangedProjects()
+        findChangedProjects(config.top, config.includeUncommitted)
     }
 
     private val dependentProjects by lazy {
@@ -401,9 +401,13 @@ class AffectedModuleDetectorImpl constructor(
      *
      * Also populates the unknownFiles var which is used in findAffectedProjects
      */
-    private fun findChangedProjects(): Set<Project> {
+    private fun findChangedProjects(
+        top: Sha,
+        includeUncommitted: Boolean = true
+    ): Set<Project> {
         git.findChangedFiles(
-            includeUncommitted = true
+            top = top,
+            includeUncommitted = includeUncommitted
         ).forEach { fileName ->
             if (affectsAllModules(fileName)) {
                 return allProjects

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/GitClient.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/GitClient.kt
@@ -83,7 +83,7 @@ internal class GitClientImpl(
         return commandRunner.executeAndParse(if (includeUncommitted) {
             "$CHANGED_FILES_CMD_PREFIX $sha"
         } else {
-            "$CHANGED_FILES_CMD_PREFIX $top $sha"
+            "$CHANGED_FILES_CMD_PREFIX $top..$sha"
         })
     }
 

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleConfigurationTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleConfigurationTest.kt
@@ -216,4 +216,47 @@ class AffectedModuleConfigurationTest {
             assertThat(config.compareFrom).isEqualTo("PreviousCommit")
         }
     }
+
+    @Test
+    fun `GIVEN AffectedModuleConfiguration WHEN top THEN is HEAD`() {
+        val actual = config.top
+
+        assertThat(actual).isEqualTo("HEAD")
+    }
+
+    @Test
+    fun `GIVEN AffectedModuleConfiguration WHEN includeUncommitted is true top is set to sha THEN exception thrown and value not set`() {
+        val includeUncommitted = true
+        val sha = "12345"
+
+        try {
+            config.includeUncommitted = includeUncommitted
+            config.top = sha
+        } catch (e: IllegalArgumentException) {
+            // THEN
+            assertThat(e.message).isEqualTo("Set includeUncommitted to false to set a custom top")
+            return
+        }
+
+        fail("Expected to catch an exception")
+    }
+
+    @Test
+    fun `GIVEN AffectedModuleConfiguration WHEN includeUncommitted is false and top is set to sha THEN top is sha`() {
+        val includeUncommitted = false
+        val sha = "12345"
+
+        config.includeUncommitted = includeUncommitted
+        config.top = sha
+
+        val actual = config.top
+        assertThat(actual).isEqualTo(sha)
+    }
+
+    @Test
+    fun `GIVEN AffectedModuleConfiguration WHEN includeUncommitted THEN is true`() {
+        val actual = config.includeUncommitted
+
+        assertThat(actual).isTrue()
+    }
 }

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/GitClientImplTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/GitClientImplTest.kt
@@ -61,7 +61,7 @@ class GitClientImplTest {
                 convertToFilePath("a", "b", "c.java"),
                 convertToFilePath("d", "e", "f.java"))
         commandRunner.addReply(
-                "$CHANGED_FILES_CMD_PREFIX otherSha mySha",
+                "$CHANGED_FILES_CMD_PREFIX otherSha..mySha",
                 changes.joinToString(System.lineSeparator())
         )
         commitShaProvider.addReply("mySha")


### PR DESCRIPTION
The `GitClient` has support to include uncommitted code and setting a custom top but that functionality was all hard coded. This PR adds the ability to configure those in the `AffectedModuleConfiguration`