### PR TITLE
Update to new Sonatype host

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,14 @@ allprojects {
     }
 }
 
+allprojects {
+    plugins.withId("com.vanniktech.maven.publish") {
+        mavenPublish {
+            sonatypeHost = "S01"
+        }
+    }
+}
+
 task clean(type: Delete) {
     delete rootProject.buildDir
 }


### PR DESCRIPTION
Following steps in https://github.com/vanniktech/gradle-maven-publish-plugin#where-to-upload-to for pointing to the new host.