### PR TITLE
Fix code to better support when running project with configuration cache

### DIFF
--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetector.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetector.kt
@@ -216,7 +216,7 @@ abstract class AffectedModuleDetector {
             )
         }
 
-        private fun isProjectEnabled(project: Project): Boolean {
+        internal fun isProjectEnabled(project: Project): Boolean {
             return project.hasProperty(ENABLE_ARG)
         }
 

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorPlugin.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorPlugin.kt
@@ -136,14 +136,14 @@ class AffectedModuleDetectorPlugin : Plugin<Project> {
         task.description = taskType.taskDescription
 
         rootProject.subprojects { project ->
-            project.afterEvaluate {
+            project.afterEvaluate { evaluatedProject ->
                 pluginIds.forEach { pluginId ->
                     if (pluginId == PLUGIN_JAVA_LIBRARY || pluginId == PLUGIN_KOTLIN) {
                         if (taskType == InternalTaskType.ANDROID_JVM_TEST) {
-                            withPlugin(pluginId, task, InternalTaskType.JVM_TEST, project)
+                            withPlugin(pluginId, task, InternalTaskType.JVM_TEST, evaluatedProject)
                         }
                     } else {
-                        withPlugin(pluginId, task, taskType, project)
+                        withPlugin(pluginId, task, taskType, evaluatedProject)
                     }
                 }
             }
@@ -163,8 +163,11 @@ class AffectedModuleDetectorPlugin : Plugin<Project> {
                 }
 
                 project.afterEvaluate {
-                    project.tasks.findByPath(path)?.onlyIf {
-                        AffectedModuleDetector.isProjectAffected(project)
+                    project.tasks.findByPath(path)?.onlyIf { task ->
+                        when {
+                            !AffectedModuleDetector.isProjectEnabled(task.project) -> true
+                            else -> AffectedModuleDetector.isProjectAffected(task.project)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This PR has two fixes
1. We no longer capture the `project` in our `afterEvaluate` statement
2. Now if the affected module detector is not enabled, we don't check to see if the project is affected when deciding to run the task