### PR TITLE
Upgrade Gradle Plugin so we can have knowledge of how to disable config cache

### DIFF
--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorPlugin.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorPlugin.kt
@@ -96,6 +96,7 @@ class AffectedModuleDetectorPlugin : Plugin<Project> {
             val task = rootProject.tasks.register(taskType.commandByImpact).get()
             task.group = CUSTOM_TASK_GROUP_NAME
             task.description = taskType.taskDescription
+            disableConfigCache(task)
 
             rootProject.subprojects { project ->
                 pluginIds.forEach { pluginId ->
@@ -136,9 +137,7 @@ class AffectedModuleDetectorPlugin : Plugin<Project> {
         val task = rootProject.tasks.register(taskType.commandByImpact).get()
         task.group = groupName
         task.description = taskType.taskDescription
-        if (GradleVersion.current() >= GradleVersion.version("7.4")) {
-            task.notCompatibleWithConfigurationCache("AMD requires knowledge of what has changed in the file system so we can not cache those values (https://github.com/dropbox/AffectedModuleDetector/issues/150)")
-        }
+        disableConfigCache(task)
 
         rootProject.subprojects { project ->
             project.afterEvaluate {
@@ -152,6 +151,12 @@ class AffectedModuleDetectorPlugin : Plugin<Project> {
                     }
                 }
             }
+        }
+    }
+
+    private fun disableConfigCache(task: Task) {
+        if (GradleVersion.current() >= GradleVersion.version("7.4")) {
+            task.notCompatibleWithConfigurationCache("AMD requires knowledge of what has changed in the file system so we can not cache those values (https://github.com/dropbox/AffectedModuleDetector/issues/150)")
         }
     }
 

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorPlugin.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorPlugin.kt
@@ -9,6 +9,7 @@ import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.tasks.testing.Test
 import org.gradle.internal.impldep.org.jetbrains.annotations.VisibleForTesting
+import org.gradle.util.GradleVersion
 
 /**
  * This plugin creates and registers all affected test tasks.
@@ -125,6 +126,7 @@ class AffectedModuleDetectorPlugin : Plugin<Project> {
         )
     }
 
+    @Suppress("UnstableApiUsage")
     @VisibleForTesting
     internal fun registerInternalTask(
         rootProject: Project,
@@ -134,6 +136,9 @@ class AffectedModuleDetectorPlugin : Plugin<Project> {
         val task = rootProject.tasks.register(taskType.commandByImpact).get()
         task.group = groupName
         task.description = taskType.taskDescription
+        if (GradleVersion.current() >= GradleVersion.version("7.4")) {
+            task.notCompatibleWithConfigurationCache("AMD requires knowledge of what has changed in the file system so we can not cache those values (https://github.com/dropbox/AffectedModuleDetector/issues/150)")
+        }
 
         rootProject.subprojects { project ->
             project.afterEvaluate {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-rc-4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-rc-4-bin.zip

--- a/sample/gradle/wrapper/gradle-wrapper.properties
+++ b/sample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip


### PR DESCRIPTION
In order to call `notCompatibleWithConfigurationCache` we need to be on at least Gradle 7.4 so we updated the plugin and disabled config cache for any custom tasks made using AMD

https://github.com/dropbox/AffectedModuleDetector/issues/150