### PR TITLE
Excluded modules should not be added to task graph

### DIFF
--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorPlugin.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorPlugin.kt
@@ -255,7 +255,7 @@ class AffectedModuleDetectorPlugin : Plugin<Project> {
     private fun requireConfiguration(project: Project): AffectedModuleConfiguration {
         return requireNotNull(
             value = project.rootProject.extensions.findByName(AffectedModuleConfiguration.name),
-            lazyMessage = {  "Unable to find ${AffectedTestConfiguration.name} in ${project.rootProject}" }
+            lazyMessage = {  "Unable to find ${AffectedModuleConfiguration.name} in ${project.rootProject}" }
         ) as AffectedModuleConfiguration
     }
 

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorIntegrationTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorIntegrationTest.kt
@@ -114,4 +114,82 @@ class AffectedModuleDetectorIntegrationTest {
         assertThat(result.output).contains(":sample-core:assembleAndroidTest SKIPPED")
         assertThat(result.output).contains(":assembleAffectedAndroidTests SKIPPED")
     }
+
+    @Test
+    fun `GIVEN multiple project with one excluded WHEN plugin is applied THEN tasks has dependencies minus the exclusions`() {
+        // GIVEN
+        tmpFolder.newFolder("sample-app")
+        tmpFolder.newFolder("sample-core")
+        tmpFolder.newFile("settings.gradle").writeText(
+            """
+                |include ':sample-app'
+                |include ':sample-core'
+                """.trimMargin()
+        )
+
+        tmpFolder.newFile("build.gradle").writeText(
+            """buildscript {
+                |   repositories {
+                |       google()
+                |       jcenter()
+                |   }
+                |   dependencies {
+                |       classpath "com.android.tools.build:gradle:4.1.0"
+                |       classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10"
+                |   }    
+                |}
+                |plugins {
+                |   id "com.dropbox.affectedmoduledetector"
+                |}
+                |affectedModuleDetector {
+                |   excludedModules = [ "sample-core" ]
+                |}
+                |allprojects {
+                |   repositories {
+                |       google()
+                |       jcenter()
+                |   }
+                |}""".trimMargin()
+        )
+
+        tmpFolder.newFile("sample-app/build.gradle").writeText(
+            """plugins {
+                |     id 'com.android.application'
+                |     id 'kotlin-android'
+                |   }
+                |   android {
+                |       compileSdkVersion 30
+                |       buildToolsVersion "30.0.2"
+                |   }
+                |   dependencies {
+                |     implementation project(":sample-core")
+                |   }""".trimMargin()
+        )
+
+        tmpFolder.newFile("sample-core/build.gradle").writeText(
+            """plugins {
+                |   id 'com.android.library'
+                |   id 'kotlin-android'
+                |   }
+                |   affectedTestConfiguration {
+                |       assembleAndroidTestTask = "assembleAndroidTest"
+                |   }
+                |   android {
+                |       compileSdkVersion 30
+                |       buildToolsVersion "30.0.2"
+                |   }""".trimMargin()
+        )
+
+        // WHEN
+        val result = GradleRunner.create()
+            .withProjectDir(tmpFolder.root)
+            .withPluginClasspath()
+            .withArguments("assembleAffectedAndroidTests", "--dry-run")
+            .build()
+
+        // THEN
+        assertThat(result.output).contains(":sample-app:assembleDebugAndroidTest SKIPPED")
+        assertThat(result.output).doesNotContain(":sample-core:assembleAndroidTest SKIPPED")
+        assertThat(result.output).contains(":assembleAffectedAndroidTests SKIPPED")
+    }
 }


### PR DESCRIPTION
Fixes #159 

I believe this fix should handle excluded modules not being added at all to the task graph by checking the configuration before adding it