### PR TITLE
Switch registering tasks to lazy

### DIFF
--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorPluginTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorPluginTest.kt
@@ -82,6 +82,7 @@ class AffectedModuleDetectorPluginTest {
         // GIVEN
         val task = fakeTask
         val plugin = AffectedModuleDetectorPlugin()
+        rootProject.pluginManager.apply(AffectedModuleDetectorPlugin::class.java)
 
         // WHEN
         plugin.registerInternalTask(


### PR DESCRIPTION
Switches the task registration to be lazy. This was broken by the call to `.get()` but now seems to handle better

Previous build scan: https://scans.gradle.com/s/n4zr3vwp5elaa/performance/configuration
- 0.024s to apply plugin
- 17 tasks created

Build scan after changes: https://scans.gradle.com/s/4j4n4rie4siwu/performance/configuration
- 0.005s to apply plugin
- 0 tasks created