### PR TITLE
Experimental Windows support - take 2

### DIFF
--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleConfiguration.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleConfiguration.kt
@@ -1,5 +1,6 @@
 package com.dropbox.affectedmoduledetector
 
+import com.dropbox.affectedmoduledetector.util.toOsSpecificPath
 import java.io.File
 
 class AffectedModuleConfiguration {
@@ -66,7 +67,8 @@ class AffectedModuleConfiguration {
             requireNotNull(baseDir) {
                 "baseDir must be set to use pathsAffectingAllModules"
             }
-            field = value
+            // Protect against users specifying the wrong path separator for their OS.
+            field = value.map { it.toOsSpecificPath() }.toSet()
         }
         get() {
             field.forEach { path ->

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleConfiguration.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleConfiguration.kt
@@ -42,7 +42,7 @@ class AffectedModuleConfiguration {
      * @see CustomTask - Implementation class
      * @see AffectedModuleDetectorPlugin - gradle plugin
      */
-    var customTasks = emptySet<AffectedModuleConfiguration.CustomTask>()
+    var customTasks = emptySet<CustomTask>()
 
     /**
      * Folder to place the log in

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetector.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetector.kt
@@ -26,6 +26,7 @@ import com.dropbox.affectedmoduledetector.AffectedModuleDetector.Companion.DEPEN
 import com.dropbox.affectedmoduledetector.AffectedModuleDetector.Companion.ENABLE_ARG
 import com.dropbox.affectedmoduledetector.AffectedModuleDetector.Companion.MODULES_ARG
 import com.dropbox.affectedmoduledetector.commitshaproviders.CommitShaProvider
+import com.dropbox.affectedmoduledetector.util.toPathSections
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -496,9 +497,13 @@ class AffectedModuleDetectorImpl constructor(
         }
     }
 
-    private fun affectsAllModules(file: String): Boolean {
+    private fun affectsAllModules(relativeFilePath: String): Boolean {
         logger?.info("Paths affecting all modules: ${config.pathsAffectingAllModules}")
-        return config.pathsAffectingAllModules.any { file.startsWith(it) }
+
+        val pathSections = relativeFilePath.toPathSections(rootProject.projectDir, git.getGitRoot())
+        val projectRelativePath = pathSections.joinToString(File.separatorChar.toString())
+
+        return config.pathsAffectingAllModules.any { projectRelativePath.startsWith(it) }
     }
 
     private fun findContainingProject(filePath: String): Project? {

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/GitClient.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/GitClient.kt
@@ -30,6 +30,7 @@ interface GitClient {
         top: Sha = "HEAD",
         includeUncommitted: Boolean = false
     ): List<String>
+
     fun getGitRoot(): File
 
     /**
@@ -40,10 +41,12 @@ interface GitClient {
          * Executes the given shell command and returns the stdout as a string.
          */
         fun execute(command: String): String
+
         /**
          * Executes the given shell command and returns the stdout by lines.
          */
         fun executeAndParse(command: String): List<String>
+
         /**
          * Executes the given shell command and returns the first stdout line.
          */
@@ -97,6 +100,7 @@ internal class GitClientImpl(
         }
         return null
     }
+
     @Suppress("LongParameterList")
     private fun parseCommitLogString(
         commitLogString: String,
@@ -162,6 +166,7 @@ internal class GitClientImpl(
             check(proc.exitValue() == 0) { "Nonzero exit value running git command." }
             return stdout
         }
+
         override fun executeAndParse(command: String): List<String> {
             val response = execute(command)
                 .split(System.lineSeparator())

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/ProjectGraph.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/ProjectGraph.kt
@@ -20,6 +20,7 @@
 
 package com.dropbox.affectedmoduledetector
 
+import com.dropbox.affectedmoduledetector.util.toPathSections
 import org.gradle.api.Project
 import org.gradle.api.logging.Logger
 import java.io.File

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/ProjectGraph.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/ProjectGraph.kt
@@ -1,22 +1,22 @@
- /*
- * Copyright 2018 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/*
+* Copyright 2018 The Android Open Source Project
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 
- /*
- * Copyright (c) 2020, Dropbox, Inc. All rights reserved.
- */
+/*
+* Copyright (c) 2020, Dropbox, Inc. All rights reserved.
+*/
 
 package com.dropbox.affectedmoduledetector
 
@@ -24,7 +24,7 @@ import org.gradle.api.Project
 import org.gradle.api.logging.Logger
 import java.io.File
 
- /**
+/**
  * Creates a project graph for fast lookup by file path
  */
 internal class ProjectGraph(project: Project, val gitRoot: File, val logger: Logger? = null) {

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/ProjectGraph.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/ProjectGraph.kt
@@ -52,24 +52,11 @@ internal class ProjectGraph(project: Project, val gitRoot: File, val logger: Log
      * Finds the project that contains the given file.
      * The file's path prefix should match the project's path.
      */
-    fun findContainingProject(filePath: String): Project? {
-        val sections = filePath.split(File.separatorChar)
-        val realSections = sections.toMutableList()
-        val projectRelativeDir = findProjectRelativeDir()
-        for (dir in projectRelativeDir) {
-            if (realSections.isNotEmpty() && dir == realSections.first()) {
-                realSections.removeAt(0)
-            } else {
-                break
-            }
-        }
+    fun findContainingProject(relativeFilePath: String): Project? {
+        val pathSections = relativeFilePath.toPathSections(rootProjectDir, gitRoot)
 
-        logger?.info("finding containing project for $filePath , sections: $realSections")
-        return rootNode.find(realSections, 0)
-    }
-
-    private fun findProjectRelativeDir(): List<String> {
-        return rootProjectDir.toRelativeString(gitRoot).split(File.separatorChar)
+        logger?.info("finding containing project for $relativeFilePath , sections: $pathSections")
+        return rootNode.find(pathSections, 0)
     }
 
     private class Node(val logger: Logger? = null) {

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/util/File.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/util/File.kt
@@ -1,0 +1,24 @@
+package com.dropbox.affectedmoduledetector.util
+
+import java.io.File
+
+/**
+ * Converts a [String] representation of a relative [File] path to sections based on the OS
+ * specific separator character.
+ */
+fun String.toPathSections(rootProjectDir: File, gitRootDir: File): List<String> {
+    val realSections = toOsSpecificPath()
+        .split(File.separatorChar)
+        .toMutableList()
+    val projectRelativeDirectorySections = rootProjectDir
+        .toRelativeString(gitRootDir)
+        .split(File.separatorChar)
+    for (directorySection in projectRelativeDirectorySections) {
+        if (realSections.isNotEmpty() && realSections.first() == directorySection) {
+            realSections.removeAt(0)
+        } else {
+            break
+        }
+    }
+    return realSections.toList()
+}

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/util/OsQuirks.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/util/OsQuirks.kt
@@ -1,0 +1,25 @@
+package com.dropbox.affectedmoduledetector.util
+
+import java.io.File
+
+/**
+ * Returns an OS specific path respecting the separator character for the operating system.
+ *
+ * The Git client appears to only talk Unix-like paths however the Gradle client understands all
+ * OS path variations. This causes issues on systems other than those that use the "/" path
+ * character i.e. Windows. Therefore we need to normalise the path.
+ */
+fun String.toOsSpecificPath(): String {
+    return this.split("/").joinToString(File.separator)
+}
+
+/**
+ * Returns a String with an OS specific line endings for the operating system.
+ *
+ * The Git client appears to only talk Unix-like line endings ("\n") however the Gradle client
+ * understands all OS line ending variants. This causes issues on systems other than those that
+ * use Unix-like line endings i.e. Windows. Therefore we need to normalise the line endings.
+ */
+fun String.toOsSpecificLineEnding(): String {
+    return this.replace("\n", System.lineSeparator())
+}

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleConfigurationTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleConfigurationTest.kt
@@ -46,7 +46,7 @@ class AffectedModuleConfigurationTest {
     @Test
     fun `GIVEN AffectedModuleConfiguration WHEN log folder is set THEN log folder is set`() {
         // GIVEN
-        val sample = "sammple"
+        val sample = "sample"
 
         // WHEN
         config.logFolder = sample

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorImplTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorImplTest.kt
@@ -21,9 +21,11 @@ class AffectedModuleDetectorImplTest {
     @JvmField
     val attachLogsRule = AttachLogsTestRule()
     private val logger = attachLogsRule.logger
+
     @Rule
     @JvmField
     val tmpFolder = TemporaryFolder()
+
     @Rule
     @JvmField
     val tmpFolder2 = TemporaryFolder()
@@ -43,10 +45,10 @@ class AffectedModuleDetectorImplTest {
     private lateinit var p12: Project
     private lateinit var p13: Project
     private val pathsAffectingAllModules = setOf(
-        "tools/android/buildSrc",
-        "android/gradlew",
-        "android/gradle",
-        "dbx/core/api/"
+        convertToFilePath("tools", "android", "buildSrc"),
+        convertToFilePath("android", "gradlew"),
+        convertToFilePath("android", "gradle"),
+        convertToFilePath("dbx", "core", "api")
     )
     private lateinit var affectedModuleConfiguration: AffectedModuleConfiguration
 
@@ -81,18 +83,21 @@ class AffectedModuleDetectorImplTest {
 
          */
 
+        // Root projects
         root = ProjectBuilder.builder()
             .withProjectDir(tmpDir)
             .withName("root")
             .build()
         // Project Graph expects supportRootFolder.
-        (root.properties.get("ext") as ExtraPropertiesExtension).set("supportRootFolder", tmpDir)
+        (root.properties["ext"] as ExtraPropertiesExtension).set("supportRootFolder", tmpDir)
         root2 = ProjectBuilder.builder()
             .withProjectDir(tmpDir2)
             .withName("root2/ui")
             .build()
         // Project Graph expects supportRootFolder.
-        (root2.properties.get("ext") as ExtraPropertiesExtension).set("supportRootFolder", tmpDir2)
+        (root2.properties["ext"] as ExtraPropertiesExtension).set("supportRootFolder", tmpDir2)
+
+        // Library modules
         p1 = ProjectBuilder.builder()
             .withProjectDir(tmpDir.resolve("p1"))
             .withName("p1")
@@ -104,21 +109,21 @@ class AffectedModuleDetectorImplTest {
             .withParent(root)
             .build()
         p3 = ProjectBuilder.builder()
-            .withProjectDir(tmpDir.resolve("p1:p3"))
+            .withProjectDir(tmpDir.resolve("p1/p3"))
             .withName("p3")
             .withParent(p1)
             .build()
         val p3config = p3.configurations.create("p3config")
         p3config.dependencies.add(p3.dependencies.project(mutableMapOf("path" to ":p1")))
         p4 = ProjectBuilder.builder()
-            .withProjectDir(tmpDir.resolve("p1:p3:p4"))
+            .withProjectDir(tmpDir.resolve("p1/p3/p4"))
             .withName("p4")
             .withParent(p3)
             .build()
         val p4config = p4.configurations.create("p4config")
         p4config.dependencies.add(p4.dependencies.project(mutableMapOf("path" to ":p1:p3")))
         p5 = ProjectBuilder.builder()
-            .withProjectDir(tmpDir.resolve("p2:p5"))
+            .withProjectDir(tmpDir.resolve("p2/p5"))
             .withName("p5")
             .withParent(p2)
             .build()
@@ -126,7 +131,7 @@ class AffectedModuleDetectorImplTest {
         p5config.dependencies.add(p5.dependencies.project(mutableMapOf("path" to ":p2")))
         p5config.dependencies.add(p5.dependencies.project(mutableMapOf("path" to ":p1:p3")))
         p6 = ProjectBuilder.builder()
-            .withProjectDir(tmpDir.resolve("p1:p3:p6"))
+            .withProjectDir(tmpDir.resolve("p1/p3/p6"))
             .withName("p6")
             .withParent(p3)
             .build()
@@ -152,6 +157,8 @@ class AffectedModuleDetectorImplTest {
             .withName("benchmark")
             .withParent(root)
             .build()
+
+        // UI modules
         p12 = ProjectBuilder.builder()
             .withProjectDir(tmpDir2.resolve("compose"))
             .withName("compose")
@@ -630,6 +637,7 @@ class AffectedModuleDetectorImplTest {
             )
         )
     }
+
     @Test
     fun changeInNormalOnlyDependent_normalBuild() {
         val detector = AffectedModuleDetectorImpl(

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorIntegrationTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorIntegrationTest.kt
@@ -1,38 +1,38 @@
 package com.dropbox.affectedmoduledetector
 
+import com.dropbox.affectedmoduledetector.rules.SetupAndroidProject
 import com.google.common.truth.Truth.assertThat
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.Rule
 import org.junit.Test
-import org.junit.rules.TemporaryFolder
 
 class AffectedModuleDetectorIntegrationTest {
 
     @Rule
     @JvmField
-    val tmpFolder = TemporaryFolder()
+    val tmpFolder = SetupAndroidProject()
 
     @Test
     fun `GIVEN single project WHEN plugin is applied THEN tasks are added`() {
         // GIVEN
         // expected tasks
         val tasks = listOf(
-                "runAffectedUnitTests",
-                "runAffectedAndroidTests",
-                "assembleAffectedAndroidTests"
+            "runAffectedUnitTests",
+            "runAffectedAndroidTests",
+            "assembleAffectedAndroidTests"
         )
         tmpFolder.newFile("build.gradle").writeText(
-                """plugins {
+            """plugins {
                 |   id "com.dropbox.affectedmoduledetector"
                 |}""".trimMargin()
         )
 
         // WHEN
         val result = GradleRunner.create()
-                .withProjectDir(tmpFolder.root)
-                .withPluginClasspath()
-                .withArguments("tasks")
-                .build()
+            .withProjectDir(tmpFolder.root)
+            .withPluginClasspath()
+            .withArguments("tasks")
+            .build()
 
         // THEN
         tasks.forEach { taskName ->
@@ -43,17 +43,18 @@ class AffectedModuleDetectorIntegrationTest {
     @Test
     fun `GIVEN multiple project WHEN plugin is applied THEN tasks has dependencies`() {
         // GIVEN
+        tmpFolder.setupAndroidSdkLocation()
         tmpFolder.newFolder("sample-app")
         tmpFolder.newFolder("sample-core")
         tmpFolder.newFile("settings.gradle").writeText(
-                """
+            """
                 |include ':sample-app'
                 |include ':sample-core'
                 """.trimMargin()
         )
 
         tmpFolder.newFile("build.gradle").writeText(
-                """buildscript {
+            """buildscript {
                 |   repositories {
                 |       google()
                 |       jcenter()
@@ -75,7 +76,7 @@ class AffectedModuleDetectorIntegrationTest {
         )
 
         tmpFolder.newFile("sample-app/build.gradle").writeText(
-                """plugins {
+            """plugins {
                 |     id 'com.android.application'
                 |     id 'kotlin-android'
                 |   }
@@ -89,7 +90,7 @@ class AffectedModuleDetectorIntegrationTest {
         )
 
         tmpFolder.newFile("sample-core/build.gradle").writeText(
-                """plugins {
+            """plugins {
                 |   id 'com.android.library'
                 |   id 'kotlin-android'
                 |   }
@@ -104,10 +105,10 @@ class AffectedModuleDetectorIntegrationTest {
 
         // WHEN
         val result = GradleRunner.create()
-                .withProjectDir(tmpFolder.root)
-                .withPluginClasspath()
-                .withArguments("assembleAffectedAndroidTests", "--dry-run")
-                .build()
+            .withProjectDir(tmpFolder.root)
+            .withPluginClasspath()
+            .withArguments("assembleAffectedAndroidTests", "--dry-run")
+            .build()
 
         // THEN
         assertThat(result.output).contains(":sample-app:assembleDebugAndroidTest SKIPPED")

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/rules/SetupAndroidProject.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/rules/SetupAndroidProject.kt
@@ -1,0 +1,44 @@
+package com.dropbox.affectedmoduledetector.rules
+
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.io.FileNotFoundException
+
+/**
+ * TestRule that allows setup of the Android SDK within the context of a GradleRunner test.
+ */
+class SetupAndroidProject : TemporaryFolder() {
+
+    /**
+     * Setup the Android SDK location for test involving Gradle and the Android Gradle DSL.
+     *
+     * Users may have configured their machine with an environment variable ANDROID_SDK_ROOT in
+     * which case the Android SDK will automatically be found using this. Otherwise we attempt to
+     * local the machine specific local.properties file and copy the contents.
+     */
+    fun setupAndroidSdkLocation() {
+        // If we happen to have already set this environment variable then we are all good to go.
+        // Nothing to see here. Move along.
+        if (!System.getenv("ANDROID_SDK_ROOT").isNullOrBlank()) return
+
+        // Find the local.properties file. File works relative to the nearest build.gradle which
+        // is the one for the Gradle module that we are currently running tests in - not the root
+        // project. But assuming that we will only ever be one level deep then we can simply use
+        // ".." to go up one level where we _should_ find our file.
+        val localDotProperties = File("../local.properties")
+
+        if (!localDotProperties.exists()) throw FileNotFoundException(
+            """
+                |Unable to locate Android SDK. Ensure that you have either the ANDROID_SDK_ROOT 
+                |environment variable set or the sdk.dir location correctly set in local
+                |.properties within the Gradle root project directory.
+            """.trimMargin()
+        )
+
+        // Read our machine specific local.properties file and copy it to our temp Gradle test
+        // directory for the test.
+        localDotProperties.bufferedReader().use {
+            newFile("local.properties").writeText(it.readText())
+        }
+    }
+}


### PR DESCRIPTION
Attempt to address #37 by adding experimental Windows support (I say _experimental_ because really what we should be doing is using an abstract file system like the one from [Okio ](https://square.github.io/okio/#file-system-examples) and write proper tests for each known target platform - Linux, Mac, Windows. However to begin with I just wanted to get something that worked on Windows.)

The main issue I noticed was that `GitClientImpl` seems to always return Unix-like line endings and path separators - `"\n"` / `"/"`. However Gradle returns the appropriate constants for the target operating system. On Windows this is `"\r\n"` / `"\"`. The AffectedModuleDetector (at its heart) compares the output from Git with the output from Gradle and compares the two to work out changes. Therefore each output needs to be in the same format. 

The main changes are:
1. Convert line endings and path separators from the output of Git to the OS specific versions to match what Gradle will do.
2. General whitespace cleanup.
3. Add a TestRule to ensure that the Android SDK location is known to the integration tests (not everyone has an environment variable set 😉 ).
4. Change use of illegal characters on Windows file systems in tests (cannot use `":"` on Windows 😢 ).

This is a reworking of #77 done in my own time on my own laptop so that I can happily sign the CLA that took so long for my company to give me any sort of answer for :sweat_smile: . It also only adds Windows support and not the _weird Gradle project structure_ support nor the build file changes as I realise the original PR was a bit messy in mixing all these concerns.