### PR TITLE
Support exotic gradle projects

### DIFF
--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorImplTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorImplTest.kt
@@ -62,22 +62,25 @@ class AffectedModuleDetectorImplTest {
         }
 
         /*
+        d: File directories
+        p: Gradle projects
 
         Dummy project file tree:
-               "library modules"           "UI modules"
-               root -----------------       root2
-              / |  \     |   |   |   |       /  |  \
-            p1  p7  p2  p8   p9 p10  p11    p12 p13 p14
+           "library modules"                 "UI modules"
+              tmpDir --------------             tmpDir2
+              / |  \     |   |    |             /    \
+            d1  d7  d2  d8   d9  d10           d12   d13 (d10)
            /         \
-          p3          p5
+          d3          d5
          /  \
-       p4   p6
+       d4   d6
 
         Dependency forest:
-
-            p1    p2    p7 p8  p9 p10 p11     p12 p14
-           /  \  /  \               \
-          p3   p5   p6               p13
+               root -------------------           root2
+              /    \     |    |   |   |           /   \
+            p1     p2    p7  p8  p9  p10         p12  p13
+           /      /  \
+          p3 --- p5   p6
          /
         p4
 
@@ -99,31 +102,31 @@ class AffectedModuleDetectorImplTest {
 
         // Library modules
         p1 = ProjectBuilder.builder()
-            .withProjectDir(tmpDir.resolve("p1"))
+            .withProjectDir(tmpDir.resolve("d1"))
             .withName("p1")
             .withParent(root)
             .build()
         p2 = ProjectBuilder.builder()
-            .withProjectDir(tmpDir.resolve("p2"))
+            .withProjectDir(tmpDir.resolve("d2"))
             .withName("p2")
             .withParent(root)
             .build()
         p3 = ProjectBuilder.builder()
-            .withProjectDir(tmpDir.resolve("p1/p3"))
+            .withProjectDir(tmpDir.resolve("d1/d3"))
             .withName("p3")
             .withParent(p1)
             .build()
         val p3config = p3.configurations.create("p3config")
         p3config.dependencies.add(p3.dependencies.project(mutableMapOf("path" to ":p1")))
         p4 = ProjectBuilder.builder()
-            .withProjectDir(tmpDir.resolve("p1/p3/p4"))
+            .withProjectDir(tmpDir.resolve("d1/d3/d4"))
             .withName("p4")
             .withParent(p3)
             .build()
         val p4config = p4.configurations.create("p4config")
         p4config.dependencies.add(p4.dependencies.project(mutableMapOf("path" to ":p1:p3")))
         p5 = ProjectBuilder.builder()
-            .withProjectDir(tmpDir.resolve("p2/p5"))
+            .withProjectDir(tmpDir.resolve("d2/d5"))
             .withName("p5")
             .withParent(p2)
             .build()
@@ -131,29 +134,29 @@ class AffectedModuleDetectorImplTest {
         p5config.dependencies.add(p5.dependencies.project(mutableMapOf("path" to ":p2")))
         p5config.dependencies.add(p5.dependencies.project(mutableMapOf("path" to ":p1:p3")))
         p6 = ProjectBuilder.builder()
-            .withProjectDir(tmpDir.resolve("p1/p3/p6"))
+            .withProjectDir(tmpDir.resolve("d1/d3/d6"))
             .withName("p6")
             .withParent(p3)
             .build()
         val p6config = p6.configurations.create("p6config")
         p6config.dependencies.add(p6.dependencies.project(mutableMapOf("path" to ":p2")))
         p7 = ProjectBuilder.builder()
-            .withProjectDir(tmpDir.resolve("p7"))
+            .withProjectDir(tmpDir.resolve("d7"))
             .withName("p7")
             .withParent(root)
             .build()
         p8 = ProjectBuilder.builder()
-            .withProjectDir(tmpDir.resolve("p8"))
+            .withProjectDir(tmpDir.resolve("d8"))
             .withName("cobuilt1")
             .withParent(root)
             .build()
         p9 = ProjectBuilder.builder()
-            .withProjectDir(tmpDir.resolve("p9"))
+            .withProjectDir(tmpDir.resolve("d9"))
             .withName("cobuilt2")
             .withParent(root)
             .build()
         p10 = ProjectBuilder.builder()
-            .withProjectDir(tmpDir.resolve("p10"))
+            .withProjectDir(tmpDir.resolve("d10"))
             .withName("benchmark")
             .withParent(root)
             .build()
@@ -166,7 +169,7 @@ class AffectedModuleDetectorImplTest {
             .build()
         // The existence of this project is a test for the benchmark use case. It is picked up by
         p13 = ProjectBuilder.builder() // allProjects in ui, even though it is in the root1 dir
-            .withProjectDir(tmpDir.resolve("p10")) // and is symlinked as p10
+            .withProjectDir(tmpDir.resolve("d10")) // and is symlinked as p10
             .withName("benchmark")
             .withParent(root2)
             .build()
@@ -248,7 +251,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                changedFiles = listOf(convertToFilePath("p1", "foo.java")),
+                changedFiles = listOf(convertToFilePath("d1", "foo.java")),
                 tmpFolder = tmpFolder.root
             ),
             config = affectedModuleConfiguration
@@ -269,7 +272,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.DEPENDENT_PROJECTS,
             injectedGitClient = MockGitClient(
-                changedFiles = listOf(convertToFilePath("p1", "foo.java")),
+                changedFiles = listOf(convertToFilePath("d1", "foo.java")),
                 tmpFolder = tmpFolder.root
             ),
             config = affectedModuleConfiguration
@@ -290,7 +293,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.CHANGED_PROJECTS,
             injectedGitClient = MockGitClient(
-                changedFiles = listOf(convertToFilePath("p1", "foo.java")),
+                changedFiles = listOf(convertToFilePath("d1", "foo.java")),
                 tmpFolder = tmpFolder.root
             ),
             config = affectedModuleConfiguration
@@ -312,8 +315,8 @@ class AffectedModuleDetectorImplTest {
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
                 changedFiles = listOf(
-                    convertToFilePath("p1", "foo.java"),
-                    convertToFilePath("p2", "bar.java")
+                    convertToFilePath("d1", "foo.java"),
+                    convertToFilePath("d2", "bar.java")
                 ),
                 tmpFolder = tmpFolder.root
             ),
@@ -336,8 +339,8 @@ class AffectedModuleDetectorImplTest {
             projectSubset = ProjectSubset.DEPENDENT_PROJECTS,
             injectedGitClient = MockGitClient(
                 changedFiles = listOf(
-                    convertToFilePath("p1", "foo.java"),
-                    convertToFilePath("p2", "bar.java")
+                    convertToFilePath("d1", "foo.java"),
+                    convertToFilePath("d2", "bar.java")
                 ),
                 tmpFolder = tmpFolder.root
             ),
@@ -360,8 +363,8 @@ class AffectedModuleDetectorImplTest {
             projectSubset = ProjectSubset.CHANGED_PROJECTS,
             injectedGitClient = MockGitClient(
                 changedFiles = listOf(
-                    convertToFilePath("p1", "foo.java"),
-                    convertToFilePath("p2", "bar.java")
+                    convertToFilePath("d1", "foo.java"),
+                    convertToFilePath("d2", "bar.java")
                 ),
                 tmpFolder = tmpFolder.root
             ),
@@ -425,7 +428,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.CHANGED_PROJECTS,
             injectedGitClient = MockGitClient(
-                changedFiles = listOf("foo.java", convertToFilePath("p7", "bar.java")),
+                changedFiles = listOf("foo.java", convertToFilePath("d7", "bar.java")),
                 tmpFolder = tmpFolder.root
             ),
             config = affectedModuleConfiguration
@@ -598,7 +601,7 @@ class AffectedModuleDetectorImplTest {
             injectedGitClient = MockGitClient(
                 changedFiles = listOf(
                     convertToFilePath(
-                        "p8", "foo.java"
+                        "d8", "foo.java"
                     )
                 ),
                 tmpFolder = tmpFolder.root
@@ -623,7 +626,7 @@ class AffectedModuleDetectorImplTest {
             injectedGitClient = MockGitClient(
                 changedFiles = listOf(
                     convertToFilePath(
-                        "p8", "foo.java"
+                        "d8", "foo.java"
                     )
                 ),
                 tmpFolder = tmpFolder.root
@@ -648,7 +651,7 @@ class AffectedModuleDetectorImplTest {
             injectedGitClient = MockGitClient(
                 changedFiles = listOf(
                     convertToFilePath(
-                        "p8", "foo.java"
+                        "d8", "foo.java"
                     )
                 ),
                 tmpFolder = tmpFolder.root
@@ -673,7 +676,7 @@ class AffectedModuleDetectorImplTest {
             injectedGitClient = MockGitClient(
                 changedFiles = listOf(
                     convertToFilePath(
-                        "p8", "foo.java"
+                        "d8", "foo.java"
                     )
                 ),
                 tmpFolder = tmpFolder.root
@@ -697,7 +700,7 @@ class AffectedModuleDetectorImplTest {
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
                 changedFiles = listOf(
-                    convertToFilePath("p7", "foo.java"),
+                    convertToFilePath("d7", "foo.java"),
                     convertToFilePath("compose", "foo.java")
                 ),
                 tmpFolder = tmpFolder.root
@@ -721,7 +724,7 @@ class AffectedModuleDetectorImplTest {
             projectSubset = ProjectSubset.CHANGED_PROJECTS,
             injectedGitClient = MockGitClient(
                 changedFiles = listOf(
-                    convertToFilePath("p7", "foo.java"),
+                    convertToFilePath("d7", "foo.java"),
                     convertToFilePath("compose", "foo.java")
                 ),
                 tmpFolder = tmpFolder.root
@@ -745,7 +748,7 @@ class AffectedModuleDetectorImplTest {
             projectSubset = ProjectSubset.DEPENDENT_PROJECTS,
             injectedGitClient = MockGitClient(
                 changedFiles = listOf(
-                    convertToFilePath("p7", "foo.java"),
+                    convertToFilePath("d7", "foo.java"),
                     convertToFilePath("compose", "foo.java")
                 ),
                 tmpFolder = tmpFolder.root
@@ -769,7 +772,7 @@ class AffectedModuleDetectorImplTest {
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
                 changedFiles = listOf(
-                    convertToFilePath("p7", "foo.java"),
+                    convertToFilePath("d7", "foo.java"),
                     convertToFilePath("compose", "foo.java")
                 ),
                 tmpFolder = tmpFolder.root
@@ -793,7 +796,7 @@ class AffectedModuleDetectorImplTest {
             projectSubset = ProjectSubset.CHANGED_PROJECTS,
             injectedGitClient = MockGitClient(
                 changedFiles = listOf(
-                    convertToFilePath("p7", "foo.java"),
+                    convertToFilePath("d7", "foo.java"),
                     convertToFilePath("compose", "foo.java")
                 ),
                 tmpFolder = tmpFolder.root
@@ -817,7 +820,7 @@ class AffectedModuleDetectorImplTest {
             projectSubset = ProjectSubset.DEPENDENT_PROJECTS,
             injectedGitClient = MockGitClient(
                 changedFiles = listOf(
-                    convertToFilePath("p7", "foo.java"),
+                    convertToFilePath("d7", "foo.java"),
                     convertToFilePath("compose", "foo.java")
                 ),
                 tmpFolder = tmpFolder.root
@@ -1023,7 +1026,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.CHANGED_PROJECTS,
             injectedGitClient = MockGitClient(
-                changedFiles = listOf(convertToFilePath("p1", "foo.java")),
+                changedFiles = listOf(convertToFilePath("d1", "foo.java")),
                 tmpFolder = tmpFolder.root
             ),
             config = affectedModuleConfiguration
@@ -1066,7 +1069,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.DEPENDENT_PROJECTS,
             injectedGitClient = MockGitClient(
-                changedFiles = listOf(convertToFilePath("p1", "foo.java")),
+                changedFiles = listOf(convertToFilePath("d1", "foo.java")),
                 tmpFolder = tmpFolder.root
             ),
             config = affectedModuleConfiguration
@@ -1109,7 +1112,7 @@ class AffectedModuleDetectorImplTest {
             ignoreUnknownProjects = false,
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             injectedGitClient = MockGitClient(
-                changedFiles = listOf(convertToFilePath("p1", "foo.java")),
+                changedFiles = listOf(convertToFilePath("d1", "foo.java")),
                 tmpFolder = tmpFolder.root
             ),
             config = affectedModuleConfiguration
@@ -1188,7 +1191,7 @@ class AffectedModuleDetectorImplTest {
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             modules = setOf(":p1"),
             injectedGitClient = MockGitClient(
-                changedFiles = listOf(convertToFilePath("p1", "foo.java")),
+                changedFiles = listOf(convertToFilePath("d1", "foo.java")),
                 tmpFolder = tmpFolder.root
             ),
             config = affectedModuleConfiguration
@@ -1207,7 +1210,7 @@ class AffectedModuleDetectorImplTest {
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             modules = emptySet(),
             injectedGitClient = MockGitClient(
-                changedFiles = listOf(convertToFilePath("p1", "foo.java")),
+                changedFiles = listOf(convertToFilePath("d1", "foo.java")),
                 tmpFolder = tmpFolder.root
             ),
             config = affectedModuleConfiguration
@@ -1227,7 +1230,7 @@ class AffectedModuleDetectorImplTest {
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             modules = null,
             injectedGitClient = MockGitClient(
-                changedFiles = listOf(convertToFilePath("p1", "foo.java")),
+                changedFiles = listOf(convertToFilePath("d1", "foo.java")),
                 tmpFolder = tmpFolder.root
             ),
             config = affectedModuleConfiguration
@@ -1250,7 +1253,7 @@ class AffectedModuleDetectorImplTest {
             projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
             modules = null,
             injectedGitClient = MockGitClient(
-                changedFiles = listOf(convertToFilePath("p1", "foo.java")),
+                changedFiles = listOf(convertToFilePath("d1", "foo.java")),
                 tmpFolder = tmpFolder.root
             ),
             config = affectedModuleConfiguration


### PR DESCRIPTION
~~Will eventually fix~~ fixes #174 ~~however for the time being this only does~~ by doing the following:

1. Cleans up the testing diagram in `AffectedModuleDetectorImplTest`
    * I found it a little difficult understanding the tests and how the diagram played a part in them so have renamed File (directory) references to `d` and the Gradle project references to `p`. We could have chosen any identifier but it was a little confusing for me that they were both the same not being familiar with the Gradle test tooling.
2. Adds failing tests to highlight the issue better.
3. Strips out `".."` markers in the relative project paths so that we can directly compare the Git with Gradle.

Here's a picture of how one might set up Gradle in this weird... quixotic..... way. (Excuse the typo in the screenshot :smile: )

![image](https://user-images.githubusercontent.com/4974178/201373896-0e510768-14ab-429a-9e22-085b9896e52d.png)

The project is declared in the same way but it's location is changed from the default location. Perfectly valid in Gradle..... not very common.... and not (yet) supported in AMD. After this change we will be able to support both.

