### PR TITLE
Allow exclude by regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ affectedModuleDetector {
     logFolder = "${project.rootDir}/output"
     compareFrom = "PreviousCommit" //default is PreviousCommit
     excludedModules = [
-        "sample-util"
+        "sample-util", ":(app|library):.+"
     ]
     includeUncommitted = true
     top = "HEAD"
@@ -116,7 +116,7 @@ affectedModuleDetector {
     - SpecifiedBranchCommitMergeBase: compare against the nearest ancestors with `$specifiedBranch` using `git merge base` approach.
     
  **Note:** specify the branch to compare changes against using the `specifiedBranch` configuration before the `compareFrom` configuration
- - `excludedModules`: A list of modules that will be excluded from the build process
+ - `excludedModules`: A list of modules that will be excluded from the build process, can be the name of a module, or a regex against the module gradle path
  - `includeUncommitted`: If uncommitted files should be considered affected
  - `top`: The top of the git log to use. Must be used in combination with configuration `includeUncommitted = false`
  - `customTasks`: set of [CustomTask](https://github.com/dropbox/AffectedModuleDetector/blob/main/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleConfiguration.kt)

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetector.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetector.kt
@@ -366,7 +366,9 @@ class AffectedModuleDetectorImpl constructor(
         val isRootProject = project.isRoot
         val isProjectAffected = affectedProjects.contains(project)
         val isProjectProvided = isProjectProvided2(project)
-        val isNotModuleExcluded = !config.excludedModules.contains(project.name)
+        val isModuleExcludedByName = config.excludedModules.contains(project.name)
+        val isModuleExcludedByRegex = config.excludedModules.any { project.path.matches(it.toRegex()) }
+        val isNotModuleExcluded = !(isModuleExcludedByName || isModuleExcludedByRegex)
 
         val shouldInclude = (isRootProject || (isProjectAffected && isProjectProvided)) && isNotModuleExcluded
         logger?.info("checking whether I should include ${project.path} and my answer is $shouldInclude")

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorImplTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorImplTest.kt
@@ -1261,6 +1261,34 @@ class AffectedModuleDetectorImplTest {
     }
 
     @Test
+    fun `GIVEN regex is in excludedModules configuration WHEN shouldInclude THEN excluded module false AND dependent modules true`() {
+        affectedModuleConfiguration = affectedModuleConfiguration.also {
+            it.excludedModules = setOf(":p1:p3:[a-zA-Z0-9:]+")
+        }
+        val detector = AffectedModuleDetectorImpl(
+            rootProject = root,
+            logger = logger,
+            ignoreUnknownProjects = false,
+            projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
+            modules = null,
+            injectedGitClient = MockGitClient(
+                changedFiles = listOf(
+                    convertToFilePath("p1/p3", "foo.java"),
+                    convertToFilePath("p1/p3/p4", "foo.java"),
+                    convertToFilePath("p2/p5", "foo.java"),
+                    convertToFilePath("p1/p3/p6", "foo.java")
+                ),
+                tmpFolder = tmpFolder.root
+            ),
+            config = affectedModuleConfiguration
+        )
+        Truth.assertThat(detector.shouldInclude(p3)).isTrue()
+        Truth.assertThat(detector.shouldInclude(p4)).isFalse()
+        Truth.assertThat(detector.shouldInclude(p5)).isTrue()
+        Truth.assertThat(detector.shouldInclude(p6)).isFalse()
+    }
+
+    @Test
     fun `GIVEN a file that effects all changes has a change WHEN projectSubset is CHANGED_PROJECTS THEN all modules should be in this`() {
         val changedFile = convertToFilePath("android", "gradle", "test.java")
 


### PR DESCRIPTION
- Previously you could exclude by module name (https://github.com/dropbox/AffectedModuleDetector/pull/54)
- Now you can still exclude by module name but also exclude against module path using a regex

For a module like `:a:b:c:d`

the name is "d" and the path is ":a:b:c:d".

You could now exclude using multiple styles:

```
excludedModules = [
   "d",
   ":a:b:c:d",
   ":.+:d",
]
```
(you would just use one of the 3 above strings.)