### PR TITLE
Remove unnecessary mutability

### DIFF
--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorPlugin.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorPlugin.kt
@@ -125,7 +125,6 @@ class AffectedModuleDetectorPlugin : Plugin<Project> {
         )
     }
 
-    @Suppress("UnstableApiUsage")
     @VisibleForTesting
     internal fun registerInternalTask(
         rootProject: Project,
@@ -170,16 +169,15 @@ class AffectedModuleDetectorPlugin : Plugin<Project> {
         }
 
         project.pluginManager.withPlugin(pluginId) {
-            getAffectedPath(testType, project)?.let { path ->
-                if (AffectedModuleDetector.isProjectProvided(project) && !isExcludedModule(config, path)) {
-                    task.dependsOn(path)
-                }
+            val path = getAffectedPath(testType, project)
+            if (AffectedModuleDetector.isProjectProvided(project) && !isExcludedModule(config, path)) {
+                task.dependsOn(path)
+            }
 
-                project.tasks.findByPath(path)?.onlyIf { task ->
-                    when {
-                        !AffectedModuleDetector.isProjectEnabled(task.project) -> true
-                        else -> AffectedModuleDetector.isProjectAffected(task.project)
-                    }
+            project.tasks.findByPath(path)?.onlyIf { task ->
+                when {
+                    !AffectedModuleDetector.isProjectEnabled(task.project) -> true
+                    else -> AffectedModuleDetector.isProjectAffected(task.project)
                 }
             }
         }
@@ -188,7 +186,7 @@ class AffectedModuleDetectorPlugin : Plugin<Project> {
     private fun getAffectedPath(
         taskType: AffectedModuleTaskType,
         project: Project
-    ): String? {
+    ): String {
         val tasks = requireNotNull(
             value = project.extensions.findByName(AffectedTestConfiguration.name),
             lazyMessage = { "Unable to find ${AffectedTestConfiguration.name} in $project" }
@@ -217,8 +215,8 @@ class AffectedModuleDetectorPlugin : Plugin<Project> {
         }
     }
 
-    private fun getPathAndTask(project: Project, task: String?): String? {
-        return if (task.isNullOrBlank()) null else "${project.path}:${task}"
+    private fun getPathAndTask(project: Project, task: String): String {
+        return "${project.path}:${task}"
     }
 
     private fun filterAndroidTests(project: Project) {

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedTestConfiguration.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedTestConfiguration.kt
@@ -6,11 +6,11 @@ package com.dropbox.affectedmoduledetector
  *  assembleAndroidTestTask = "assembleDevDebugAndroidTest"
  * }
  */
-open class AffectedTestConfiguration {
-
-    var assembleAndroidTestTask : String? = DEFAULT_ASSEMBLE_ANDROID_TEST_TASK
-    var runAndroidTestTask : String?  = DEFAULT_ANDROID_TEST_TASK
-    var jvmTestTask : String? = DEFAULT_JVM_TEST_TASK
+open class AffectedTestConfiguration(
+    val assembleAndroidTestTask: String = DEFAULT_ASSEMBLE_ANDROID_TEST_TASK,
+    val runAndroidTestTask: String = DEFAULT_ANDROID_TEST_TASK,
+    val jvmTestTask: String = DEFAULT_JVM_TEST_TASK,
+) {
 
     companion object {
         const val name = "affectedTestConfiguration"

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedTestConfigurationTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedTestConfigurationTest.kt
@@ -1,20 +1,13 @@
 package com.dropbox.affectedmoduledetector
 
 import com.google.common.truth.Truth.assertThat
-import org.junit.Before
 import org.junit.Test
 
 class AffectedTestConfigurationTest {
 
-    private lateinit var config : AffectedTestConfiguration
-
-    @Before
-    fun setup() {
-        config = AffectedTestConfiguration()
-    }
-
     @Test
     fun `GIVEN AffectedTestConfiguration WHEN default values THEN default values returned`() {
+        val config = AffectedTestConfiguration()
         assertThat(config.assembleAndroidTestTask).isEqualTo("assembleDebugAndroidTest")
         assertThat(config.runAndroidTestTask).isEqualTo("connectedDebugAndroidTest")
         assertThat(config.jvmTestTask).isEqualTo("testDebugUnitTest")
@@ -28,9 +21,11 @@ class AffectedTestConfigurationTest {
         val jvmTest = "jvmTest"
 
         // WHEN
-        config.assembleAndroidTestTask = assembleAndroidTestTask
-        config.runAndroidTestTask = runAndroidTestTask
-        config.jvmTestTask = jvmTest
+        val config = AffectedTestConfiguration(
+            assembleAndroidTestTask,
+            runAndroidTestTask,
+            jvmTest,
+        )
 
         // THEN
         assertThat(config.assembleAndroidTestTask).isEqualTo(assembleAndroidTestTask)


### PR DESCRIPTION
The `open class AffectedTestConfiguration` had its fields as `var` it looked like this was done for the tests.

Re-jigged the test so that the `AffectedTestConfiguration` class can use `val` which allows the prod code to have less mutability, making it easier to reason about.

TLDR; `task` is never "null or blank".

Also removed `@Suppress("UnstableApiUsage")` which the IDE highlighted was unnecessary.