### PR TITLE
Fix directory names in tests

### DIFF
--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorImplTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorImplTest.kt
@@ -1456,10 +1456,10 @@ class AffectedModuleDetectorImplTest {
             modules = null,
             injectedGitClient = MockGitClient(
                 changedFiles = listOf(
-                    convertToFilePath("p1/p3", "foo.java"),
-                    convertToFilePath("p1/p3/p4", "foo.java"),
-                    convertToFilePath("p2/p5", "foo.java"),
-                    convertToFilePath("p1/p3/p6", "foo.java")
+                    convertToFilePath("d1/d3", "foo.java"),
+                    convertToFilePath("d1/d3/d4", "foo.java"),
+                    convertToFilePath("d2/d5", "foo.java"),
+                    convertToFilePath("d1/d3/d6", "foo.java")
                 ),
                 tmpFolder = tmpFolder.root
             ),


### PR DESCRIPTION
These changed in #178 but due to race conditions in the merge the test began to fail