### PR TITLE
Add the ability to configure ignoredFiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ affectedModuleDetector {
     excludedModules = [
         "sample-util", ":(app|library):.+"
     ]
+    ignoredFiles = [
+        "*.md", "*.txt", "README"
+    ]
     includeUncommitted = true
     top = "HEAD"
     customTasks = [
@@ -109,6 +112,7 @@ affectedModuleDetector {
  - `logFilename`: A filename for the output detector to use
  - `logFolder`: A folder to output the log file in
  - `specifiedBranch`: A branch to specify changes against. Must be used in combination with configuration `compareFrom = "SpecifiedBranchCommit"` 
+ - `ignoredFiles`: A set of files that will be filtered out of the list of changed files retrieved by git. 
  - `compareFrom`: A commit to compare the branch changes against. Can be either:
     - PreviousCommit: compare against the previous commit
     - ForkCommit: compare against the commit the branch was forked from

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ affectedModuleDetector {
         "sample-util", ":(app|library):.+"
     ]
     ignoredFiles = [
-        "*.md", "*.txt", "README"
+        ".*\\.md", ".*\\.txt", ".*README"
     ]
     includeUncommitted = true
     top = "HEAD"

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleConfiguration.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleConfiguration.kt
@@ -106,6 +106,11 @@ class AffectedModuleConfiguration {
     var excludedModules = emptySet<String>()
 
     /**
+     * A set of files that will be filtered out of the list of changed files retrieved by git.
+     */
+    var ignoredFiles = emptySet<String>()
+
+    /**
      * If uncommitted files should be considered affected
      */
     var includeUncommitted: Boolean = true

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetector.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetector.kt
@@ -330,7 +330,8 @@ class AffectedModuleDetectorImpl constructor(
         injectedGitClient ?: GitClientImpl(
             rootProject.projectDir,
             logger,
-            commitShaProvider = CommitShaProvider.fromString(config.compareFrom, config.specifiedBranch)
+            commitShaProvider = CommitShaProvider.fromString(config.compareFrom, config.specifiedBranch),
+            ignoredFiles = config.ignoredFiles
         )
     }
 

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/GitClientImplTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/GitClientImplTest.kt
@@ -27,17 +27,24 @@ class GitClientImplTest {
         workingDir = workingDir,
         logger = logger,
         commandRunner = commandRunner,
-        commitShaProvider = commitShaProvider
+        commitShaProvider = commitShaProvider,
+        ignoredFiles = setOf(".*\\.ignore", ".*IGNORED_FILE")
     )
 
     @Test
     fun givenChangedFiles_whenFindChangedFilesIncludeUncommitted_thenReturnChanges() {
         val changes = listOf(
+                convertToFilePath("d", "e", ".ignoredNot"),
                 convertToFilePath("a", "b", "c.java"),
                 convertToFilePath("d", "e", "f.java"))
+        val changesWithIgnores = listOf(
+                convertToFilePath("a", "b", "anything.ignore"),
+                convertToFilePath("d", "e", ".ignore"),
+                convertToFilePath("d", "e", "IGNORED_FILE")
+        ) + changes
         commandRunner.addReply(
                 "$CHANGED_FILES_CMD_PREFIX mySha",
-                changes.joinToString(System.lineSeparator())
+            changesWithIgnores.joinToString(System.lineSeparator())
         )
         commitShaProvider.addReply("mySha")
 
@@ -58,11 +65,17 @@ class GitClientImplTest {
     @Test
     fun findChangesSince_twoCls() {
         val changes = listOf(
+                convertToFilePath("d", "e", ".ignoredNot"),
                 convertToFilePath("a", "b", "c.java"),
                 convertToFilePath("d", "e", "f.java"))
+        val changesWithIgnores = listOf(
+                convertToFilePath("a", "b", "anything.ignore"),
+                convertToFilePath("d", "e", ".ignore"),
+                convertToFilePath("d", "e", "IGNORED_FILE")
+        ) + changes
         commandRunner.addReply(
                 "$CHANGED_FILES_CMD_PREFIX otherSha..mySha",
-                changes.joinToString(System.lineSeparator())
+            changesWithIgnores.joinToString(System.lineSeparator())
         )
         commitShaProvider.addReply("mySha")
         assertEquals(


### PR DESCRIPTION
It would be useful to have the ability to configure files to be ignored by the plugin.
With this functionality, you could filter files like markdown docs so your pipelines can run faster.