### PR TITLE
Set up dependOn task only if project is affected

### DIFF
--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorIntegrationTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorIntegrationTest.kt
@@ -111,8 +111,8 @@ class AffectedModuleDetectorIntegrationTest {
             .build()
 
         // THEN
-        assertThat(result.output).contains(":sample-app:assembleDebugAndroidTest SKIPPED")
-        assertThat(result.output).contains(":sample-core:assembleAndroidTest SKIPPED")
+        assertThat(result.output).doesNotContain(":sample-app:assembleDebugAndroidTest SKIPPED")
+        assertThat(result.output).doesNotContain(":sample-core:assembleAndroidTest SKIPPED")
         assertThat(result.output).contains(":assembleAffectedAndroidTests SKIPPED")
     }
 
@@ -189,7 +189,7 @@ class AffectedModuleDetectorIntegrationTest {
             .build()
 
         // THEN
-        assertThat(result.output).contains(":sample-app:assembleDebugAndroidTest SKIPPED")
+        assertThat(result.output).doesNotContain(":sample-app:assembleDebugAndroidTest SKIPPED")
         assertThat(result.output).doesNotContain(":sample-core:assembleAndroidTest SKIPPED")
         assertThat(result.output).contains(":assembleAffectedAndroidTests SKIPPED")
     }

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorIntegrationTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorIntegrationTest.kt
@@ -111,8 +111,8 @@ class AffectedModuleDetectorIntegrationTest {
             .build()
 
         // THEN
-        assertThat(result.output).doesNotContain(":sample-app:assembleDebugAndroidTest")
-        assertThat(result.output).doesNotContain(":sample-core:assembleAndroidTest")
+        assertThat(result.output).contains(":sample-app:assembleDebugAndroidTest SKIPPED")
+        assertThat(result.output).contains(":sample-core:assembleAndroidTest SKIPPED")
         assertThat(result.output).contains(":assembleAffectedAndroidTests SKIPPED")
     }
 
@@ -189,7 +189,7 @@ class AffectedModuleDetectorIntegrationTest {
             .build()
 
         // THEN
-        assertThat(result.output).doesNotContain(":sample-app:assembleDebugAndroidTest")
+        assertThat(result.output).contains(":sample-app:assembleDebugAndroidTest SKIPPED")
         assertThat(result.output).doesNotContain(":sample-core:assembleAndroidTest")
         assertThat(result.output).contains(":assembleAffectedAndroidTests SKIPPED")
     }

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorIntegrationTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorIntegrationTest.kt
@@ -112,6 +112,9 @@ class AffectedModuleDetectorIntegrationTest {
 
         // THEN
         assertThat(result.output).contains(":sample-app:assembleDebugAndroidTest SKIPPED")
+        assertThat(result.output).contains(":sample-core:mergeDexDebugAndroidTest SKIPPED")
+        assertThat(result.output).contains(":sample-core:packageDebugAndroidTest SKIPPED")
+        assertThat(result.output).contains(":sample-core:assembleDebugAndroidTest SKIPPED")
         assertThat(result.output).contains(":sample-core:assembleAndroidTest SKIPPED")
         assertThat(result.output).contains(":assembleAffectedAndroidTests SKIPPED")
     }
@@ -190,6 +193,9 @@ class AffectedModuleDetectorIntegrationTest {
 
         // THEN
         assertThat(result.output).contains(":sample-app:assembleDebugAndroidTest SKIPPED")
+        assertThat(result.output).doesNotContain(":sample-core:mergeDexDebugAndroidTest")
+        assertThat(result.output).doesNotContain(":sample-core:packageDebugAndroidTest")
+        assertThat(result.output).doesNotContain(":sample-core:assembleDebugAndroidTest")
         assertThat(result.output).doesNotContain(":sample-core:assembleAndroidTest")
         assertThat(result.output).contains(":assembleAffectedAndroidTests SKIPPED")
     }

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorIntegrationTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorIntegrationTest.kt
@@ -111,8 +111,8 @@ class AffectedModuleDetectorIntegrationTest {
             .build()
 
         // THEN
-        assertThat(result.output).doesNotContain(":sample-app:assembleDebugAndroidTest SKIPPED")
-        assertThat(result.output).doesNotContain(":sample-core:assembleAndroidTest SKIPPED")
+        assertThat(result.output).doesNotContain(":sample-app:assembleDebugAndroidTest")
+        assertThat(result.output).doesNotContain(":sample-core:assembleAndroidTest")
         assertThat(result.output).contains(":assembleAffectedAndroidTests SKIPPED")
     }
 
@@ -189,8 +189,8 @@ class AffectedModuleDetectorIntegrationTest {
             .build()
 
         // THEN
-        assertThat(result.output).doesNotContain(":sample-app:assembleDebugAndroidTest SKIPPED")
-        assertThat(result.output).doesNotContain(":sample-core:assembleAndroidTest SKIPPED")
+        assertThat(result.output).doesNotContain(":sample-app:assembleDebugAndroidTest")
+        assertThat(result.output).doesNotContain(":sample-core:assembleAndroidTest")
         assertThat(result.output).contains(":assembleAffectedAndroidTests SKIPPED")
     }
 }

--- a/sample/buildSrc/src/main/kotlin/com/dropbox/sample/tasks/AffectedTasksPlugin.kt
+++ b/sample/buildSrc/src/main/kotlin/com/dropbox/sample/tasks/AffectedTasksPlugin.kt
@@ -53,8 +53,8 @@ class AffectedTasksPlugin : Plugin<Project> {
     private fun registerAffectedTestTask(
         taskName: String, testTask: String, testTaskBackup: String?,
         rootProject: Project
-    ): Task {
-        val task = rootProject.tasks.register(taskName) { task ->
+    ) {
+        rootProject.tasks.register(taskName) { task ->
             val paths = getAffectedPaths(testTask, testTaskBackup, rootProject)
             paths.forEach { path ->
                 task.dependsOn(path)
@@ -62,7 +62,6 @@ class AffectedTasksPlugin : Plugin<Project> {
             task.enabled = paths.isNotEmpty()
             task.onlyIf { paths.isNotEmpty() }
         }
-        return task.get()
     }
 
     private fun getAffectedPaths(


### PR DESCRIPTION
Fixes https://github.com/dropbox/AffectedModuleDetector/issues/223

This change will reduce the amount of task that needs to be configured. 
The idea is this. When a task doesn't have to run, and if we know it. There is no need to depend on that task and skip it later. The plugin can only depend on the task that should run.

I couldnt now how to test it but I compared change in our project.

| Before | After |
| - | - |
| <img width="699" alt="Screenshot 2024-02-10 at 18 51 58" src="https://github.com/dropbox/AffectedModuleDetector/assets/2559837/bf872cfc-4ad4-4ac6-9d69-1bc421e1d527"> | <img width="664" alt="Screenshot 2024-02-10 at 18 51 51" src="https://github.com/dropbox/AffectedModuleDetector/assets/2559837/c1ddc993-27c3-4c84-8304-e7185248e0fc"> | 
| <img width="539" alt="Screenshot 2024-02-10 at 18 52 21" src="https://github.com/dropbox/AffectedModuleDetector/assets/2559837/4521f63a-2a6f-455e-b3b1-92a9ec748703"> | <img width="507" alt="Screenshot 2024-02-10 at 18 52 17" src="https://github.com/dropbox/AffectedModuleDetector/assets/2559837/6d43d2c6-d6d4-4832-bce8-e707161fc271"> | 
| <img width="563" alt="Screenshot 2024-02-10 at 18 55 20" src="https://github.com/dropbox/AffectedModuleDetector/assets/2559837/b94f6395-9c0d-4ba9-999f-4459da04b01b"> | <img width="471" alt="Screenshot 2024-02-10 at 18 55 24" src="https://github.com/dropbox/AffectedModuleDetector/assets/2559837/f347560e-3b2a-4c9f-8148-77db17d32858"> |


Before the change of this pr, tasks that belong to modules that has no change or not affected also created but skipped.
After this change, tasks from unaffected modules are not created.
Any pre task that depends on actual task we are calling also being executed in original implementation.
After the change, you can see that only affected modules tasks are created and called.

(Change is in in-app-notification module)

