### PR TITLE
Update test dependencies to newer versions

### DIFF
--- a/affectedmoduledetector/build.gradle
+++ b/affectedmoduledetector/build.gradle
@@ -29,6 +29,6 @@ gradlePlugin {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     testImplementation("junit:junit:4.13.2")
-    testImplementation("com.nhaarman:mockito-kotlin:1.6.0")
-    testImplementation("com.google.truth:truth:1.1.3")
+    testImplementation("org.mockito.kotlin:mockito-kotlin:4.1.0")
+    testImplementation("com.google.truth:truth:1.4.2")
 }

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AttachLogsTestRule.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AttachLogsTestRule.kt
@@ -1,9 +1,9 @@
 package com.dropbox.affectedmoduledetector
 
-import com.nhaarman.mockito_kotlin.mock
 import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
+import org.mockito.kotlin.mock
 
 /**
  * Special rule for dependency detector tests that will attach logs to a failure.


### PR DESCRIPTION
Hello 👋 I found your plugin very interesting and I want to use it in my company's project. But before this would happen, I must be sure that it is still well maintained and there would be no issues during future collaboration, like submitting bugs or accepting changes from community. So I've prepared a small contribution, I would be very happy if you accept it and prove that this plugin is still getting some love by it's creators 😉 

Changes:
- bump `com.google.truth:truth` to `1.4.2` (IntelliJ reported that the previous version had some security vulnerabilities)
  - afaik no additional changes were necessary because of it
- replace `com.nhaarman:mockito-kotlin` with `org.mockito.kotlin:mockito-kotlin`
  - Nhaarman's library was integrated into official Mockito organization, see [link](https://github.com/mockito/mockito-kotlin?tab=readme-ov-file#acknowledgements)
  - the newest version of this library is 5.X. However, this major version requires Java 11, and your project is still on Java 8. Because of this, I've updated mockito-kotlin only to the 4.X version, which is still compatible with Java 8.