### PR TITLE
Ability to configure skipping build all

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ affectedModuleDetector {
     ignoredFiles = [
         ".*\\.md", ".*\\.txt", ".*README"
     ]
+    buildAllWhenNoProjectsChanged = true // default is true
     includeUncommitted = true
     top = "HEAD"
     customTasks = [
@@ -113,6 +114,7 @@ affectedModuleDetector {
  - `logFolder`: A folder to output the log file in
  - `specifiedBranch`: A branch to specify changes against. Must be used in combination with configuration `compareFrom = "SpecifiedBranchCommit"` 
  - `ignoredFiles`: A set of files that will be filtered out of the list of changed files retrieved by git. 
+ - `buildAllWhenNoProjectsChanged`: If true, the plugin will build all projects when no projects are considered affected.
  - `compareFrom`: A commit to compare the branch changes against. Can be either:
     - PreviousCommit: compare against the previous commit
     - ForkCommit: compare against the commit the branch was forked from

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleConfiguration.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleConfiguration.kt
@@ -116,6 +116,11 @@ class AffectedModuleConfiguration {
     var includeUncommitted: Boolean = true
 
     /**
+     * If we should build all projects when no projects have changed
+     */
+    var buildAllWhenNoProjectsChanged: Boolean = true
+
+    /**
      * The top of the git log to use, only used when [includeUncommitted] is false
      */
     var top: String = "HEAD"

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetector.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetector.kt
@@ -476,7 +476,7 @@ class AffectedModuleDetectorImpl constructor(
         var buildAll = false
 
         // Should only trigger if there are no changedFiles
-        if (changedProjects.isEmpty() && unknownFiles.isEmpty()) {
+        if (config.buildAllWhenNoProjectsChanged && changedProjects.isEmpty() && unknownFiles.isEmpty()) {
             buildAll = true
         }
         logger?.info(

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleConfigurationTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleConfigurationTest.kt
@@ -1,6 +1,8 @@
 package com.dropbox.affectedmoduledetector
 
 import com.google.common.truth.Truth.assertThat
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Rule
@@ -323,5 +325,30 @@ class AffectedModuleConfigurationTest {
         val actual = config.customTasks
 
         assert(actual.first().taskDescription == "Description of fake task")
+    }
+
+    @Test
+    fun `GIVEN AffectedModuleConfiguration WHEN buildAllWhenNoProjectsChanged THEN then default value is true`() {
+        // GIVEN
+        // config
+
+        // WHEN
+        val buildAllWhenNoProjectsChanged = config.buildAllWhenNoProjectsChanged
+
+        // THEN
+        assertTrue(buildAllWhenNoProjectsChanged)
+    }
+
+    @Test
+    fun `GIVEN AffectedModuleConfiguration WHEN buildAllWhenNoProjectsChanged is set to false THEN then value is false`() {
+        // GIVEN
+        val buildAll = false
+        config.buildAllWhenNoProjectsChanged = buildAll
+
+        // WHEN
+        val actual = config.buildAllWhenNoProjectsChanged
+
+        // THEN
+        assertFalse(actual)
     }
 }

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorImplTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorImplTest.kt
@@ -311,6 +311,29 @@ class AffectedModuleDetectorImplTest {
     }
 
     @Test
+    fun noChangeSkipAll() {
+        val detector = AffectedModuleDetectorImpl(
+            rootProject = root,
+            logger = logger,
+            ignoreUnknownProjects = false,
+            projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
+            injectedGitClient = MockGitClient(
+                changedFiles = emptyList(),
+                tmpFolder = tmpFolder.root
+            ),
+            config = affectedModuleConfiguration.also {
+                it.buildAllWhenNoProjectsChanged = false
+            }
+        )
+        MatcherAssert.assertThat(
+            detector.affectedProjects,
+            CoreMatchers.`is`(
+                emptySet()
+            )
+        )
+    }
+
+    @Test
     fun changeInOneOnlyDependent() {
         val detector = AffectedModuleDetectorImpl(
             rootProject = root,


### PR DESCRIPTION
When No projects are changed and no unknown files are detected the plugin builds all projects.

in some cases e.g. change in ignored files  it would be nice to be able to configure the default behaviour of Building all projects 