### PR TITLE
Address Issue #258: Configuration predicate to control dependency graph creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,11 @@ affectedModuleDetector {
             "Run static analysis tool without auto-correction by Impact analysis"
         )
     ]
+    configurationPredicate.set(new Predicate<Configuration>() {
+        boolean test(Configuration configuration) {
+            return !configuration.name.contains("somethingToExclude")
+        }
+    })
 }
 ```
 
@@ -124,6 +129,7 @@ affectedModuleDetector {
  - `includeUncommitted`: If uncommitted files should be considered affected
  - `top`: The top of the git log to use. Must be used in combination with configuration `includeUncommitted = false`
  - `customTasks`: set of [CustomTask](https://github.com/dropbox/AffectedModuleDetector/blob/main/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleConfiguration.kt)
+ - `configurationPredicate`: A predicate to filter configurations that should be considered for the dependency graph.  By default, all configurations are considered.
 
  By default, the Detector will look for `assembleAndroidDebugTest`, `connectedAndroidDebugTest`, and `testDebug`.  Modules can specify a configuration block to specify which variant tests to run:
  ```groovy

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleConfiguration.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleConfiguration.kt
@@ -1,9 +1,13 @@
 package com.dropbox.affectedmoduledetector
 
 import com.dropbox.affectedmoduledetector.util.toOsSpecificPath
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
 import java.io.File
+import java.util.function.Predicate
 
-class AffectedModuleConfiguration {
+class AffectedModuleConfiguration(objectFactory: ObjectFactory) {
 
     /**
      * Implementation of [AffectedModuleTaskType] for easy adding of custom gradle task to
@@ -43,6 +47,16 @@ class AffectedModuleConfiguration {
      * @see AffectedModuleDetectorPlugin - gradle plugin
      */
     var customTasks = emptySet<CustomTask>()
+
+    /**
+     * Predicate to determine if a configuration should be considered or ignored.  This predicate
+     * will be called for every configuration defined by each project module.  By default,
+     * all configurations are considered.
+     */
+    @Suppress("UNCHECKED_CAST") // Erasure in the API results in: Property<Predicate<*>>
+    val configurationPredicate: Property<Predicate<Configuration>> =
+        (objectFactory.property(Predicate::class.java) as Property<Predicate<Configuration>>)
+            .convention(AlwaysConfigurationPredicate())
 
     /**
      * Folder to place the log in

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorPlugin.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorPlugin.kt
@@ -62,7 +62,7 @@ class AffectedModuleDetectorPlugin : Plugin<Project> {
     private fun registerMainConfiguration(project: Project) {
         project.extensions.add(
             AffectedModuleConfiguration.name,
-            AffectedModuleConfiguration()
+            AffectedModuleConfiguration(project.objects)
         )
     }
 

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AlwaysConfigurationPredicate.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AlwaysConfigurationPredicate.kt
@@ -1,0 +1,14 @@
+package com.dropbox.affectedmoduledetector
+
+import org.gradle.api.artifacts.Configuration
+import java.util.function.Predicate
+
+/**
+ * Default implementation of a [Configuration] [Predicate] that always returns true, indicating
+ * that all configurations should be considered.
+ */
+internal class AlwaysConfigurationPredicate : Predicate<Configuration> {
+    override fun test(t: Configuration): Boolean {
+        return true
+    }
+}

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleConfigurationTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleConfigurationTest.kt
@@ -1,6 +1,8 @@
 package com.dropbox.affectedmoduledetector
 
+import com.dropbox.affectedmoduledetector.mocks.MockObjectFactory
 import com.google.common.truth.Truth.assertThat
+import org.gradle.api.artifacts.Configuration
 import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Rule
@@ -9,6 +11,7 @@ import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import java.io.File
+import java.util.function.Predicate
 
 @RunWith(JUnit4::class)
 class AffectedModuleConfigurationTest {
@@ -26,7 +29,7 @@ class AffectedModuleConfigurationTest {
 
     @Before
     fun setup() {
-        config = AffectedModuleConfiguration()
+        config = AffectedModuleConfiguration(MockObjectFactory())
     }
 
     @Test
@@ -323,5 +326,29 @@ class AffectedModuleConfigurationTest {
         val actual = config.customTasks
 
         assert(actual.first().taskDescription == "Description of fake task")
+    }
+
+    @Test
+    fun `GIVEN AffectedModuleConfiguration WHEN configuration predicate is set THEN is configuration predicate`() {
+        // GIVEN
+        val expected = Predicate<Configuration> { false }
+        config.configurationPredicate.set(expected)
+
+        // WHEN
+        val predicate = config.configurationPredicate.get()
+
+        // THEN
+        assertThat(predicate).isSameInstanceAs(expected)
+    }
+
+    @Test
+    fun `GIVEN AffectedModuleConfiguration WHEN configuration predicate is not set THEN is default`() {
+        // GIVEN default configuration
+
+        // WHEN
+        val predicate = config.configurationPredicate.get()
+
+        // THEN
+        assertThat(predicate).isInstanceOf(AlwaysConfigurationPredicate::class.java)
     }
 }

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorImplTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorImplTest.kt
@@ -1,5 +1,6 @@
 package com.dropbox.affectedmoduledetector
 
+import com.dropbox.affectedmoduledetector.mocks.MockObjectFactory
 import com.google.common.truth.Truth
 import org.gradle.api.Project
 import org.gradle.api.plugins.ExtraPropertiesExtension
@@ -220,9 +221,12 @@ class AffectedModuleDetectorImplTest {
         val p19config = p19.configurations.create("p19config")
         p19config.dependencies.add(p19.dependencies.project(mutableMapOf("path" to ":p18")))
 
-        affectedModuleConfiguration = AffectedModuleConfiguration().also {
+        affectedModuleConfiguration = AffectedModuleConfiguration(MockObjectFactory()).also {
             it.baseDir = tmpDir.absolutePath
             it.pathsAffectingAllModules = pathsAffectingAllModules
+        }
+        listOf(root, root2, root3).forEach { rootProject ->
+            rootProject.extensions.add(AffectedModuleConfiguration.name, affectedModuleConfiguration)
         }
     }
 
@@ -1329,7 +1333,7 @@ class AffectedModuleDetectorImplTest {
     @Test
     fun `GIVEN affected module configuration WHEN invalid path THEN throw exception`() {
         // GIVEN
-        val config = AffectedModuleConfiguration().also {
+        val config = AffectedModuleConfiguration(MockObjectFactory()).also {
             it.baseDir = tmpFolder.root.absolutePath
         }
 
@@ -1350,7 +1354,7 @@ class AffectedModuleDetectorImplTest {
     @Test
     fun `GIVEN affected module configuration WHEN valid paths THEN return paths`() {
         // GIVEN
-        val config = AffectedModuleConfiguration().also {
+        val config = AffectedModuleConfiguration(MockObjectFactory()).also {
             it.baseDir = tmpFolder.root.absolutePath
         }
 
@@ -1520,6 +1524,55 @@ class AffectedModuleDetectorImplTest {
                 setOf()
             )
         )
+    }
+
+    @Test
+    fun `GIVEN upward configuration reference from p2 to p6 WHEN no predicate is supplied THEN p2 is affected`() {
+        p2.configurations.create("p2-upward-p6") { config ->
+            config.dependencies.add(p2.dependencies.project(mapOf("path" to p6.path)))
+        }
+        val detector = AffectedModuleDetectorImpl(
+            rootProject = root,
+            logger = logger,
+            ignoreUnknownProjects = false,
+            projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
+            modules = null,
+            injectedGitClient = MockGitClient(
+                changedFiles = listOf(
+                    convertToFilePath("d1/d3/d6", "foo.java")
+                ),
+                tmpFolder = tmpFolder.root
+            ),
+            config = affectedModuleConfiguration
+        )
+        Truth.assertThat(detector.shouldInclude(p2)).isTrue()
+        Truth.assertThat(detector.shouldInclude(p6)).isTrue()
+    }
+
+    @Test
+    fun `GIVEN upward configuration reference from p2 to p6 WHEN predicate filtered THEN p2 is unaffected`() {
+        p2.configurations.create("p2-upward-p6") { config ->
+            config.dependencies.add(p2.dependencies.project(mapOf("path" to p6.path)))
+        }
+        affectedModuleConfiguration.configurationPredicate.set { configuration ->
+            !configuration.name.contains("-upward-")
+        }
+        val detector = AffectedModuleDetectorImpl(
+            rootProject = root,
+            logger = logger,
+            ignoreUnknownProjects = false,
+            projectSubset = ProjectSubset.ALL_AFFECTED_PROJECTS,
+            modules = null,
+            injectedGitClient = MockGitClient(
+                changedFiles = listOf(
+                    convertToFilePath("d1/d3/d6", "foo.java")
+                ),
+                tmpFolder = tmpFolder.root
+            ),
+            config = affectedModuleConfiguration
+        )
+        Truth.assertThat(detector.shouldInclude(p2)).isFalse()
+        Truth.assertThat(detector.shouldInclude(p6)).isTrue()
     }
 
     // For both Linux/Windows

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorPluginTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorPluginTest.kt
@@ -1,5 +1,6 @@
 package com.dropbox.affectedmoduledetector
 
+import com.dropbox.affectedmoduledetector.mocks.MockObjectFactory
 import com.google.common.truth.Truth.assertThat
 import org.gradle.api.Project
 import org.gradle.api.internal.plugins.PluginApplicationException
@@ -10,7 +11,6 @@ import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
-import java.lang.IllegalStateException
 
 @RunWith(JUnit4::class)
 class AffectedModuleDetectorPluginTest {
@@ -102,7 +102,7 @@ class AffectedModuleDetectorPluginTest {
     @Test
     fun `GIVEN affected module detector plugin WHEN register_custom_task is called AND AffectedModuleConfiguration customTask is not empty THEN task is added`() {
         // GIVEN
-        val configuration = AffectedModuleConfiguration()
+        val configuration = AffectedModuleConfiguration(MockObjectFactory())
         configuration.customTasks = setOf(fakeTask)
         rootProject.extensions.add(AffectedModuleConfiguration.name, configuration)
 
@@ -122,7 +122,7 @@ class AffectedModuleDetectorPluginTest {
     @Test
     fun `GIVEN affected module detector plugin WHEN registerCustomTasks is called AND AffectedModuleConfiguration customTask is empty THEN task isn't added`() {
         // GIVEN
-        val configuration = AffectedModuleConfiguration()
+        val configuration = AffectedModuleConfiguration(MockObjectFactory())
         rootProject.extensions.add(AffectedModuleConfiguration.name, configuration)
         val plugin = AffectedModuleDetectorPlugin()
 
@@ -144,7 +144,7 @@ class AffectedModuleDetectorPluginTest {
     @Test
     fun `GIVEN affected module detector plugin WHEN registerTestTasks THEN task all task added`() {
         // GIVEN
-        val configuration = AffectedModuleConfiguration()
+        val configuration = AffectedModuleConfiguration(MockObjectFactory())
         rootProject.extensions.add(AffectedModuleConfiguration.name, configuration)
         val plugin = AffectedModuleDetectorPlugin()
 
@@ -168,7 +168,7 @@ class AffectedModuleDetectorPluginTest {
     @Test
     fun `GIVEN affected module detector plugin WHEN registerTestTasks called THEN added all tasks from InternalTaskType`() {
         // GIVEN
-        val configuration = AffectedModuleConfiguration()
+        val configuration = AffectedModuleConfiguration(MockObjectFactory())
         rootProject.extensions.add(AffectedModuleConfiguration.name, configuration)
         val plugin = AffectedModuleDetectorPlugin()
         val availableTaskVariants = 3 // runAffectedAndroidTests, assembleAffectedAndroidTests and runAffectedUnitTests
@@ -187,7 +187,7 @@ class AffectedModuleDetectorPluginTest {
     fun `GIVEN affected module detector plugin WHEN registerCustomTasks called THEN added all tasks from FakeTaskType`() {
         // GIVEN
         val givenCustomTasks = setOf(fakeTask, fakeTask.copy(commandByImpact = "otherCommand"))
-        val configuration = AffectedModuleConfiguration()
+        val configuration = AffectedModuleConfiguration(MockObjectFactory())
         configuration.customTasks = givenCustomTasks
         rootProject.extensions.add(AffectedModuleConfiguration.name, configuration)
         val plugin = AffectedModuleDetectorPlugin()

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/mocks/MockObjectFactory.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/mocks/MockObjectFactory.kt
@@ -1,0 +1,98 @@
+package com.dropbox.affectedmoduledetector.mocks
+
+import org.gradle.api.DomainObjectSet
+import org.gradle.api.ExtensiblePolymorphicDomainObjectContainer
+import org.gradle.api.Named
+import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.api.NamedDomainObjectFactory
+import org.gradle.api.NamedDomainObjectList
+import org.gradle.api.NamedDomainObjectSet
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.ConfigurableFileTree
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.file.SourceDirectorySet
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
+
+/**
+ * Mock implementation of Gradle's [ObjectFactory] for testing purposes.
+ */
+class MockObjectFactory : ObjectFactory {
+    override fun <T : Named?> named(type: Class<T>, name: String): T {
+        TODO("Not yet implemented")
+    }
+
+    override fun <T : Any> newInstance(type: Class<out T>, vararg parameters: Any): T {
+        TODO("Not yet implemented")
+    }
+
+    override fun sourceDirectorySet(name: String, displayName: String): SourceDirectorySet {
+        TODO("Not yet implemented")
+    }
+
+    override fun fileCollection(): ConfigurableFileCollection {
+        TODO("Not yet implemented")
+    }
+
+    override fun fileTree(): ConfigurableFileTree {
+        TODO("Not yet implemented")
+    }
+
+    override fun <T : Any> domainObjectContainer(elementType: Class<T>): NamedDomainObjectContainer<T> {
+        TODO("Not yet implemented")
+    }
+
+    override fun <T : Any> domainObjectContainer(
+        elementType: Class<T>,
+        factory: NamedDomainObjectFactory<T>
+    ): NamedDomainObjectContainer<T> {
+        TODO("Not yet implemented")
+    }
+
+    override fun <T : Any> polymorphicDomainObjectContainer(elementType: Class<T>): ExtensiblePolymorphicDomainObjectContainer<T> {
+        TODO("Not yet implemented")
+    }
+
+    override fun <T : Any> domainObjectSet(elementType: Class<T>): DomainObjectSet<T> {
+        TODO("Not yet implemented")
+    }
+
+    override fun <T : Any> namedDomainObjectSet(elementType: Class<T>): NamedDomainObjectSet<T> {
+        TODO("Not yet implemented")
+    }
+
+    override fun <T : Any> namedDomainObjectList(elementType: Class<T>): NamedDomainObjectList<T> {
+        TODO("Not yet implemented")
+    }
+
+    override fun <T : Any> property(valueType: Class<T>): Property<T> {
+        return MockProperty()
+    }
+
+    override fun <T : Any> listProperty(elementType: Class<T>): ListProperty<T> {
+        TODO("Not yet implemented")
+    }
+
+    override fun <T : Any> setProperty(elementType: Class<T>): SetProperty<T> {
+        TODO("Not yet implemented")
+    }
+
+    override fun <K : Any, V : Any> mapProperty(
+        keyType: Class<K>,
+        valueType: Class<V>
+    ): MapProperty<K, V> {
+        TODO("Not yet implemented")
+    }
+
+    override fun directoryProperty(): DirectoryProperty {
+        TODO("Not yet implemented")
+    }
+
+    override fun fileProperty(): RegularFileProperty {
+        TODO("Not yet implemented")
+    }
+}

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/mocks/MockProperty.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/mocks/MockProperty.kt
@@ -1,0 +1,99 @@
+package com.dropbox.affectedmoduledetector.mocks
+
+import org.gradle.api.Transformer
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import java.util.concurrent.atomic.AtomicReference
+import java.util.function.BiFunction
+
+/**
+ * Mock implementation of the Gradle's [ObjectFactory] for testing purposes.
+ */
+class MockProperty<T : Any> : Property<T> {
+    private val valueSourceRef = AtomicReference<PropertySource<T>?>()
+    private val conventionRef = AtomicReference<PropertySource<T>?>()
+
+    override fun get(): T {
+        return getOrNull() ?: throw IllegalStateException("Property value is not set")
+    }
+
+    override fun getOrNull(): T? {
+        return valueSourceRef.get()?.get()
+            ?: conventionRef.get()?.get()
+    }
+
+    override fun isPresent(): Boolean {
+        return getOrNull() != null
+    }
+
+    @Deprecated("super is deprecated", ReplaceWith("modern stuff"))
+    override fun forUseAtConfigurationTime(): Provider<T> = this
+
+    override fun finalizeValue() {
+        // No-op
+    }
+
+    override fun finalizeValueOnRead() {
+        // No-op
+    }
+
+    override fun disallowChanges() {
+        // No-op
+    }
+
+    override fun disallowUnsafeRead() {
+        // No-op
+    }
+
+    override fun convention(provider: Provider<out T>): Property<T> = apply {
+        conventionRef.set(ProviderSource(provider))
+    }
+
+    override fun convention(value: T?): Property<T> = apply {
+        conventionRef.set(ValueSource(value))
+    }
+
+    override fun value(provider: Provider<out T>): Property<T> = apply {
+        set(provider)
+    }
+
+    override fun value(value: T?): Property<T> = apply {
+        set(value)
+    }
+
+    override fun set(provider: Provider<out T>) {
+        valueSourceRef.set(ProviderSource(provider))
+    }
+
+    override fun set(value: T?) {
+        valueSourceRef.set(ValueSource(value))
+    }
+
+    override fun <B : Any?, R : Any?> zip(
+        provider: Provider<B>,
+        biFunction: BiFunction<T, B, R>
+    ): Provider<R> {
+        TODO("Not yet implemented")
+    }
+
+    override fun orElse(provider: Provider<out T>): Provider<T> = apply {
+        conventionRef.set(ProviderSource(provider))
+    }
+
+    override fun orElse(value: T): Provider<T> = apply {
+        conventionRef.set(ValueSource(value))
+    }
+
+    override fun <S : Any?> flatMap(transformer: Transformer<out Provider<out S>, in T>): Provider<S> {
+        TODO("Not yet implemented")
+    }
+
+    override fun <S : Any?> map(transformer: Transformer<out S, in T>): Provider<S> {
+        TODO("Not yet implemented")
+    }
+
+    override fun getOrElse(defaultValue: T): T {
+        return getOrNull() ?: defaultValue
+    }
+}

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/mocks/PropertySource.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/mocks/PropertySource.kt
@@ -1,0 +1,23 @@
+package com.dropbox.affectedmoduledetector.mocks
+
+import org.gradle.api.provider.Provider
+
+/**
+ * A property source that can be used to provide a value for a property.  This makes it
+ * a bit easier for [MockProperty] to manage.
+ */
+sealed interface PropertySource<out T> {
+    fun get(): T?
+}
+
+class ProviderSource<out T>(private val provider: Provider<T>) : PropertySource<T> {
+    override fun get(): T? {
+        return provider.get()
+    }
+}
+
+class ValueSource<out T>(private val value: T?) : PropertySource<T> {
+    override fun get(): T? {
+        return value
+    }
+}


### PR DESCRIPTION
Adds a new configuration option to allow the consumer to provision of a `Predicate<Configuration>` instance to customize what `Configuration` instances should be considered when building the dependency graph.

---

For your consideration, adding something like this would be very helpful for us.  Appreciate the work y'all have done thus far.

Note that the choice of `Property<Predicate<Configuration>>` was used because:
- Use of gradle properties allows the value to be changed all the way up until execution, which gets around `afterEvaluate` issues
- It exposes the actual `Configuration` instead of just its name