### PR TITLE
Add support for providing a raw commit SHA to compare against as a new comparison strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ affectedModuleDetector {
  - `logFilename`: A filename for the output detector to use
  - `logFolder`: A folder to output the log file in
  - `specifiedBranch`: A branch to specify changes against. Must be used in combination with configuration `compareFrom = "SpecifiedBranchCommit"` 
+ - `specifiedRawCommitSha`: A raw commit SHA to specify changes against. Must be used in combination with configuration `compareFrom = "SpecifiedRawCommitSha"`
  - `ignoredFiles`: A set of files that will be filtered out of the list of changed files retrieved by git. 
  - `buildAllWhenNoProjectsChanged`: If true, the plugin will build all projects when no projects are considered affected.
  - `compareFrom`: A commit to compare the branch changes against. Can be either:
@@ -120,7 +121,8 @@ affectedModuleDetector {
     - ForkCommit: compare against the commit the branch was forked from
     - SpecifiedBranchCommit: compare against the last commit of `$specifiedBranch` using `git rev-parse` approach. 
     - SpecifiedBranchCommitMergeBase: compare against the nearest ancestors with `$specifiedBranch` using `git merge base` approach.
-    
+    - SpecifiedRawCommitSha: compare against the provided raw commit SHA.
+
  **Note:** specify the branch to compare changes against using the `specifiedBranch` configuration before the `compareFrom` configuration
  - `excludedModules`: A list of modules that will be excluded from the build process, can be the name of a module, or a regex against the module gradle path
  - `includeUncommitted`: If uncommitted files should be considered affected
@@ -161,6 +163,12 @@ Suppose we have changed 6 files in our "feature" branch.
    AMD will show the result that 6 files were affected. And this is the correct behavior.
 
 Hence, depending on your CI settings you have to configure AMD appropriately. 
+
+## SpecifiedRawCommitSha
+
+If you want AMD plugin to skip performing the git operations under-the-hood (like `git rev-parse` and `git merge base`), you can provide the raw commit SHA you wish to compare against.
+One of the main reasons you might want to follow this approach is, maybe your environment leverages [Git mirroring](https://docs.github.com/en/repositories/creating-and-managing-repositories/duplicating-a-repository) for speed optimizations, for example CI/CD environments.
+Mirroring _can_ lead to inaccurate common ancestor commits as the duplicated repository _may be_ out of sync with the true remote repository.
 
 ## Sample Usage
 

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleConfiguration.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleConfiguration.kt
@@ -81,13 +81,16 @@ class AffectedModuleConfiguration {
 
     var specifiedBranch: String? = null
 
+    var specifiedRawCommitSha: String? = null
+
     var compareFrom: String = "PreviousCommit"
         set(value) {
             val commitShaProviders = listOf(
                 "PreviousCommit",
                 "ForkCommit",
                 "SpecifiedBranchCommit",
-                "SpecifiedBranchCommitMergeBase"
+                "SpecifiedBranchCommitMergeBase",
+                "SpecifiedRawCommitSha"
             )
             require(commitShaProviders.contains(value)) {
                 "The property configuration compareFrom must be one of the following: ${commitShaProviders.joinToString(", ")}"
@@ -95,6 +98,11 @@ class AffectedModuleConfiguration {
             if (value == "SpecifiedBranchCommit" || value == "SpecifiedBranchCommitMergeBase") {
                 requireNotNull(specifiedBranch) {
                     "Specify a branch using the configuration specifiedBranch"
+                }
+            }
+            if (value == "SpecifiedRawCommitSha") {
+                requireNotNull(specifiedRawCommitSha) {
+                    "Provide a Commit SHA for the specifiedRawCommitSha property when using SpecifiedRawCommitSha comparison strategy."
                 }
             }
             field = value

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetector.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetector.kt
@@ -340,7 +340,7 @@ class AffectedModuleDetectorImpl constructor(
         injectedGitClient ?: GitClientImpl(
             rootProject.projectDir,
             logger,
-            commitShaProvider = CommitShaProvider.fromString(config.compareFrom, config.specifiedBranch),
+            commitShaProvider = CommitShaProvider.fromString(config.compareFrom, config.specifiedBranch, config.specifiedRawCommitSha),
             ignoredFiles = config.ignoredFiles
         )
     }

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/CommitShaProvider.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/CommitShaProvider.kt
@@ -8,7 +8,11 @@ interface CommitShaProvider {
     fun get(commandRunner: GitClient.CommandRunner): Sha
 
     companion object {
-        fun fromString(string: String, specifiedBranch: String? = null): CommitShaProvider {
+        fun fromString(
+            string: String,
+            specifiedBranch: String? = null,
+            specifiedRawCommitSha: String? = null
+        ): CommitShaProvider {
             return when (string) {
                 "PreviousCommit" -> PreviousCommit()
                 "ForkCommit" -> ForkCommit()
@@ -23,6 +27,12 @@ interface CommitShaProvider {
                         "Specified branch must be defined"
                     }
                     SpecifiedBranchCommitMergeBase(specifiedBranch)
+                }
+                "SpecifiedRawCommitSha" -> {
+                    requireNotNull(specifiedRawCommitSha) {
+                        "Specified raw commit sha must be defined"
+                    }
+                    SpecifiedRawCommitSha(specifiedRawCommitSha)
                 }
                 else -> throw IllegalArgumentException("Unsupported compareFrom type")
             }

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/SpecifiedRawCommitSha.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/SpecifiedRawCommitSha.kt
@@ -1,0 +1,10 @@
+package com.dropbox.affectedmoduledetector.commitshaproviders
+
+import com.dropbox.affectedmoduledetector.GitClient
+import com.dropbox.affectedmoduledetector.Sha
+
+class SpecifiedRawCommitSha(private val commitSha: String) : CommitShaProvider {
+    override fun get(commandRunner: GitClient.CommandRunner): Sha {
+        return commitSha
+    }
+}

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleConfigurationTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleConfigurationTest.kt
@@ -234,13 +234,38 @@ class AffectedModuleConfigurationTest {
     }
 
     @Test
+    fun `GIVEN AffectedModuleConfiguration WHEN compareFrom is set to SpecifiedRawCommitSha THEN is SpecifiedRawCommitSha`() {
+        val specifiedRawCommitSha = "SpecifiedRawCommitSha"
+        val commitSha = "12345"
+
+        config.specifiedRawCommitSha = commitSha
+        config.compareFrom = specifiedRawCommitSha
+
+        val actual = config.compareFrom
+        assertThat(actual).isEqualTo(specifiedRawCommitSha)
+    }
+
+    @Test
+    fun `GIVEN AffectedModuleConfiguration WHEN compareFrom is set to SpecifiedRawCommitSha AND specifiedRawCommitSha not defined THEN error thrown`() {
+        val specifiedRawCommitSha = "SpecifiedRawCommitSha"
+
+        try {
+            config.compareFrom = specifiedRawCommitSha
+        } catch (e: IllegalArgumentException) {
+            // THEN
+            assertThat(e.message).isEqualTo("Provide a Commit SHA for the specifiedRawCommitSha property when using SpecifiedRawCommitSha comparison strategy.")
+            return
+        }
+    }
+
+    @Test
     fun `GIVEN AffectedModuleConfiguration WHEN compareFrom is set to invalid sha provider THEN exception thrown and value not set`() {
         try {
             config.compareFrom = "InvalidInput"
             fail()
         } catch (e: Exception) {
             assertThat(e::class).isEqualTo(IllegalArgumentException::class)
-            assertThat(e.message).isEqualTo("The property configuration compareFrom must be one of the following: PreviousCommit, ForkCommit, SpecifiedBranchCommit, SpecifiedBranchCommitMergeBase")
+            assertThat(e.message).isEqualTo("The property configuration compareFrom must be one of the following: PreviousCommit, ForkCommit, SpecifiedBranchCommit, SpecifiedBranchCommitMergeBase, SpecifiedRawCommitSha")
             assertThat(config.compareFrom).isEqualTo("PreviousCommit")
         }
     }

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorImplTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorImplTest.kt
@@ -355,7 +355,7 @@ class AffectedModuleDetectorImplTest {
         MatcherAssert.assertThat(
             detector.affectedProjects,
             CoreMatchers.`is`(
-                emptySet()
+                emptySet<Map<ProjectPath, Project>>()
             )
         )
     }

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorImplTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorImplTest.kt
@@ -355,7 +355,7 @@ class AffectedModuleDetectorImplTest {
         MatcherAssert.assertThat(
             detector.affectedProjects,
             CoreMatchers.`is`(
-                emptySet<Map<ProjectPath, Project>>()
+                emptySet()
             )
         )
     }

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/CommitShaProviderTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/CommitShaProviderTest.kt
@@ -59,6 +59,24 @@ class CommitShaProviderTest {
     }
 
     @Test
+    fun givenSpecifiedRawCommitSha_whenFromString_thenReturnSpecifiedRawCommitSha() {
+        val actual =
+            CommitShaProvider.fromString("SpecifiedRawCommitSha", specifiedRawCommitSha = "sha")
+
+        assertThat(actual::class).isEqualTo(SpecifiedRawCommitSha::class)
+    }
+
+    @Test
+    fun givenSpecifiedRawCommitShaAndSpecifiedRawCommitShaNull_whenFromString_thenThrowException() {
+        try {
+            CommitShaProvider.fromString("SpecifiedRawCommitSha")
+        } catch (e: Exception) {
+            assertThat(e::class).isEqualTo(IllegalArgumentException::class)
+            assertThat(e.message).isEqualTo("Specified raw commit sha must be defined")
+        }
+    }
+
+    @Test
     fun givenInvalidCommitString_whenFromString_thenExceptionThrown() {
         try {
             CommitShaProvider.fromString("Invalid")

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/CommitShaProviderTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/CommitShaProviderTest.kt
@@ -60,8 +60,7 @@ class CommitShaProviderTest {
 
     @Test
     fun givenSpecifiedRawCommitSha_whenFromString_thenReturnSpecifiedRawCommitSha() {
-        val actual =
-            CommitShaProvider.fromString("SpecifiedRawCommitSha", specifiedRawCommitSha = "sha")
+        val actual = CommitShaProvider.fromString("SpecifiedRawCommitSha", specifiedRawCommitSha = "sha")
 
         assertThat(actual::class).isEqualTo(SpecifiedRawCommitSha::class)
     }
@@ -73,7 +72,7 @@ class CommitShaProviderTest {
         } catch (e: Exception) {
             assertThat(e::class).isEqualTo(IllegalArgumentException::class)
             assertThat(e.message).isEqualTo("Specified raw commit sha must be defined")
-        }
+            }
     }
 
     @Test

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/CommitShaProviderTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/commitshaproviders/CommitShaProviderTest.kt
@@ -72,7 +72,7 @@ class CommitShaProviderTest {
         } catch (e: Exception) {
             assertThat(e::class).isEqualTo(IllegalArgumentException::class)
             assertThat(e.message).isEqualTo("Specified raw commit sha must be defined")
-            }
+        }
     }
 
     @Test


### PR DESCRIPTION
### Summary
- Adds a new comparison strategy, ``, that allows clients to compare against the explicitly provided commit SHA rather than relying on the plugin's git operations for determining the desired commit
- **Motivation:** It could be the case your environment leverages [git mirroring](https://docs.github.com/en/repositories/creating-and-managing-repositories/duplicating-a-repository), in which case a duped repository can be out of sync with the _true_ remote, leading to inaccurate determinations of the nearest ancestor commits. It also doesn't hurt to give developers this option if they wan't a slight optimization of bypassing the work needed by the git operations.

### Usage
```
affectedModuleDetector {
    ...
    specifiedRawCommitSha = "12a9c6dba8b8dbd7b374480f38c448f24101127f"
    compareFrom = "SpecifiedRawCommitSha"
    ...
}
```