### PR TITLE
Register new tasks after plugin is configured.

### DIFF
--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorPlugin.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorPlugin.kt
@@ -48,11 +48,11 @@ class AffectedModuleDetectorPlugin : Plugin<Project> {
 
         registerSubprojectConfiguration(project)
         registerMainConfiguration(project)
-        registerCustomTasks(project)
-        registerTestTasks(project)
 
         project.gradle.projectsEvaluated {
             AffectedModuleDetector.configure(project)
+            registerCustomTasks(project)
+            registerTestTasks(project)
             filterAndroidTests(project)
             filterJvmTests(project)
             filterCustomTasks(project)
@@ -78,9 +78,7 @@ class AffectedModuleDetectorPlugin : Plugin<Project> {
     private fun registerCustomTasks(rootProject: Project) {
         val mainConfiguration = requireConfiguration(rootProject)
 
-        rootProject.afterEvaluate {
-            registerCustomTasks(rootProject, mainConfiguration.customTasks)
-        }
+        registerCustomTasks(rootProject, mainConfiguration.customTasks)
     }
 
     @VisibleForTesting


### PR DESCRIPTION
Avoids NPE when trying to check whether a project is affected while creating tasks.

fixes #287

## Context
After #270, the plugin registers new tasks during initial setup, then configures the plugin and initializes the `AffectedModuleDetector` after projects are evaluated.  This fixed #205, but registering the test plugins requires the `AffectedModuleDetector`, which is `null` until `AffectedModuleDetector.configure(project)` is called.

`registerCustomTasks()` already wrapped its setup in `rootProject.afterEvaluate`, but `registerTestTasks()` did not.  The execution order is important here, so the `register` functions were moved after `AffectedModuleDetector.configure()`, after projects are evaluated.