### PR TITLE
fix problem with slash in branch name on Windows

### DIFF
--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/GitClient.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/GitClient.kt
@@ -156,7 +156,6 @@ private class RealCommandRunner(
     override fun executeAndParse(command: String): List<String> {
         return execute(command).toOsSpecificLineEnding()
             .split(System.lineSeparator())
-            .map { it.toOsSpecificPath() }
             .filterNot { it.isEmpty() }
     }
 
@@ -205,7 +204,7 @@ internal abstract class GitChangedFilesSource :
             } else {
                 "$CHANGED_FILES_CMD_PREFIX $top..$sha"
             }
-        )
+        ).map { it.toOsSpecificPath() }
 
         return parameters.ignoredFiles.orNull
             .orEmpty()


### PR DESCRIPTION
In 3d1b6f1 OS specific handling was added for line endings and path separators when executing Git commands.

This was over-generalizing the problem because the response of a Git command can also include a branch name and if that branch name would contain a slash (e.g. feature/my-feature) then this would be changed to a backslash on Windows which does not work.

I have removed the path separator handling from the Git command output and moved it instead to the changed file processing location.