### PR TITLE
fix root project file path not set if baseDir not configured

### DIFF
--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetector.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetector.kt
@@ -647,7 +647,7 @@ class AffectedModuleDetectorImpl(
         val rootProjectDir = if (config.baseDir != null) {
             File(config.baseDir!!)
         } else {
-            File(projectGraph.getRootProjectPath()!!.path)
+            File(projectGraph.getRootFilePath())
         }
         val pathSections = relativeFilePath.toPathSections(rootProjectDir, gitRoot)
         val projectRelativePath = pathSections.joinToString(File.separatorChar.toString())

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/ProjectGraph.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/ProjectGraph.kt
@@ -28,12 +28,14 @@ import java.io.Serializable
 /** Creates a project graph for fast lookup by file path */
 class ProjectGraph(project: Project, logger: Logger? = null) : Serializable {
     private val rootNode: Node
+    private val rootProjectDir: File
 
     init {
         // always use cannonical file: b/112205561
         logger?.info("initializing ProjectGraph")
         rootNode = Node()
-        val rootProjectDir = project.getSupportRootFolder().canonicalFile
+        rootProjectDir = project.getSupportRootFolder().canonicalFile
+        rootNode.projectPath = project.projectPath
         val projects =
             if (rootProjectDir == project.rootDir.canonicalFile) {
                 project.subprojects
@@ -70,8 +72,8 @@ class ProjectGraph(project: Project, logger: Logger? = null) : Serializable {
         return rootNode.find(sections, 0, logger)
     }
 
-    fun getRootProjectPath(): ProjectPath? {
-        return rootNode.projectPath
+    fun getRootFilePath(): String? {
+        return rootProjectDir.path
     }
 
     val allProjects by lazy {


### PR DESCRIPTION
The root project was missing its path when `baseDir` is not configured. This resulted in a NPE.
The existing logic tried to supply the Gradle module path instead of the file path while the latter is needed. 