### PR TITLE
Support tests on multiple android variants

### DIFF
--- a/affectedmoduledetector/build.gradle
+++ b/affectedmoduledetector/build.gradle
@@ -32,6 +32,7 @@ gradlePlugin {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation("com.android.tools.build:gradle:8.13.0")
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.mockito.kotlin:mockito-kotlin:6.0.0")
     testImplementation("com.google.truth:truth:1.4.5")

--- a/affectedmoduledetector/build.gradle
+++ b/affectedmoduledetector/build.gradle
@@ -32,7 +32,6 @@ gradlePlugin {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation("com.android.tools.build:gradle:8.13.0")
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.mockito.kotlin:mockito-kotlin:6.0.0")
     testImplementation("com.google.truth:truth:1.4.5")

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorPlugin.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorPlugin.kt
@@ -4,7 +4,6 @@
 
 package com.dropbox.affectedmoduledetector
 
-import com.android.build.gradle.TestedAndroidConfig
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -193,29 +192,19 @@ class AffectedModuleDetectorPlugin : Plugin<Project> {
             lazyMessage = { "Unable to find ${AffectedTestConfiguration.name} in $project" }
         ) as AffectedTestConfiguration
 
+        val androidTaskNames = tasks.testTasksProvider?.orNull
+
         return when (taskType) {
             InternalTaskType.ANDROID_TEST -> {
-                if (tasks.runTestsForEveryVariant) {
-                    getAndroidPathsAndTasks(project, tasks.defaultTestBuildType, InternalTaskType.ANDROID_TEST)
-                } else {
-                    getPathAndTask(project, tasks.runAndroidTestTask)
-                }
+                androidTaskNames?.androidTestTasks?.takeIf { it.isNotEmpty() } ?: getPathAndTask(project, tasks.runAndroidTestTask)
             }
 
             InternalTaskType.ASSEMBLE_ANDROID_TEST -> {
-                if (tasks.runTestsForEveryVariant) {
-                    getAndroidPathsAndTasks(project, tasks.defaultTestBuildType, InternalTaskType.ASSEMBLE_ANDROID_TEST)
-                } else {
-                    getPathAndTask(project, tasks.assembleAndroidTestTask)
-                }
+                androidTaskNames?.assembleAndroidTestTasks?.takeIf { it.isNotEmpty() } ?: getPathAndTask(project, tasks.assembleAndroidTestTask)
             }
 
             InternalTaskType.ANDROID_JVM_TEST -> {
-                if (tasks.runTestsForEveryVariant) {
-                    getAndroidPathsAndTasks(project, tasks.defaultTestBuildType, InternalTaskType.ANDROID_JVM_TEST)
-                } else {
-                    getPathAndTask(project, tasks.jvmTestTask)
-                }
+                androidTaskNames?.unitTestTasks?.takeIf { it.isNotEmpty() } ?: getPathAndTask(project, tasks.jvmTestTask)
             }
 
             InternalTaskType.JVM_TEST -> {
@@ -230,39 +219,6 @@ class AffectedModuleDetectorPlugin : Plugin<Project> {
                 getPathAndTask(project, taskType.originalGradleCommand)
             }
         }
-    }
-
-    private fun getAndroidPathsAndTasks(project: Project, buildType: String, taskType: InternalTaskType): List<String> {
-        val androidTestExtension = requireNotNull(
-            value = project.extensions.findByType(TestedAndroidConfig::class.java),
-            lazyMessage = { "Unable to find ${TestedAndroidConfig::class.simpleName} in $project" }
-        )
-
-        val taskSuffix = when (taskType) {
-            InternalTaskType.ANDROID_JVM_TEST -> "UnitTest"
-            InternalTaskType.ANDROID_TEST -> "AndroidTest"
-            InternalTaskType.ASSEMBLE_ANDROID_TEST -> "AndroidTest"
-            else -> throw IllegalArgumentException("Unknown task type: $taskType")
-        }
-
-        val taskPrefix = when (taskType) {
-            InternalTaskType.ANDROID_JVM_TEST -> "test"
-            InternalTaskType.ANDROID_TEST -> "test"
-            InternalTaskType.ASSEMBLE_ANDROID_TEST -> "assemble"
-            else -> throw IllegalArgumentException("Unknown task type: $taskType")
-        }
-
-        val variantSet = when (taskType) {
-            InternalTaskType.ANDROID_JVM_TEST -> androidTestExtension.unitTestVariants
-            InternalTaskType.ANDROID_TEST -> androidTestExtension.unitTestVariants
-            InternalTaskType.ASSEMBLE_ANDROID_TEST -> androidTestExtension.testVariants
-            else -> throw IllegalArgumentException("Unknown task type: $taskType")
-        }
-
-        return variantSet.matching { it.buildType.name == buildType }
-            .map { variant ->
-                "${taskPrefix}${variant.name.replaceFirstChar { it.uppercase() }}${taskSuffix}"
-            }
     }
 
     private fun getPathAndTask(project: Project, task: String?): List<String> {

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorPlugin.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetectorPlugin.kt
@@ -192,27 +192,25 @@ class AffectedModuleDetectorPlugin : Plugin<Project> {
             lazyMessage = { "Unable to find ${AffectedTestConfiguration.name} in $project" }
         ) as AffectedTestConfiguration
 
-        val androidTaskNames = tasks.testTasksProvider?.orNull
+        val androidTaskNames = tasks.getTestTaskNames()
 
         return when (taskType) {
             InternalTaskType.ANDROID_TEST -> {
-                androidTaskNames?.androidTestTasks?.takeIf { it.isNotEmpty() } ?: getPathAndTask(project, tasks.runAndroidTestTask)
+                androidTaskNames.androidTestTasks.takeIf {
+                    it.isNotEmpty()
+                } ?: getPathAndTask(project, AffectedTestConfiguration.DEFAULT_ANDROID_TEST_TASK)
             }
 
             InternalTaskType.ASSEMBLE_ANDROID_TEST -> {
-                androidTaskNames?.assembleAndroidTestTasks?.takeIf { it.isNotEmpty() } ?: getPathAndTask(project, tasks.assembleAndroidTestTask)
+                androidTaskNames.assembleAndroidTestTasks.takeIf {
+                    it.isNotEmpty()
+                } ?: getPathAndTask(project, AffectedTestConfiguration.DEFAULT_ASSEMBLE_ANDROID_TEST_TASK)
             }
 
             InternalTaskType.ANDROID_JVM_TEST -> {
-                androidTaskNames?.unitTestTasks?.takeIf { it.isNotEmpty() } ?: getPathAndTask(project, tasks.jvmTestTask)
-            }
-
-            InternalTaskType.JVM_TEST -> {
-                if (tasks.jvmTestTask != AffectedTestConfiguration.DEFAULT_JVM_TEST_TASK) {
-                    getPathAndTask(project, tasks.jvmTestTask)
-                } else {
-                    getPathAndTask(project, taskType.originalGradleCommand)
-                }
+                androidTaskNames.unitTestTasks.takeIf {
+                    it.isNotEmpty()
+                } ?: getPathAndTask(project, AffectedTestConfiguration.DEFAULT_JVM_TEST_TASK)
             }
 
             else -> {

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedTestConfiguration.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedTestConfiguration.kt
@@ -12,6 +12,9 @@ open class AffectedTestConfiguration {
     var runAndroidTestTask: String? = DEFAULT_ANDROID_TEST_TASK
     var jvmTestTask: String? = DEFAULT_JVM_TEST_TASK
 
+    var runTestsForEveryVariant: Boolean = false
+    var defaultTestBuildType: String = "debug"
+
     companion object {
         const val name = "affectedTestConfiguration"
 

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedTestConfiguration.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedTestConfiguration.kt
@@ -1,5 +1,8 @@
 package com.dropbox.affectedmoduledetector
 
+import org.gradle.api.provider.Provider
+import java.io.Serializable
+
 /**
  * Used to configure which variant to run for affected tasks by adding following block to modules
  * affectedTestConfiguration{
@@ -12,8 +15,13 @@ open class AffectedTestConfiguration {
     var runAndroidTestTask: String? = DEFAULT_ANDROID_TEST_TASK
     var jvmTestTask: String? = DEFAULT_JVM_TEST_TASK
 
-    var runTestsForEveryVariant: Boolean = false
-    var defaultTestBuildType: String = "debug"
+    var testTasksProvider: Provider<TasksNames>? = null
+
+    data class TasksNames(
+        val unitTestTasks: List<String>,
+        val androidTestTasks: List<String>,
+        val assembleAndroidTestTasks: List<String>,
+    ): Serializable
 
     companion object {
         const val name = "affectedTestConfiguration"

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedTestConfiguration.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedTestConfiguration.kt
@@ -10,17 +10,16 @@ import java.io.Serializable
  * }
  */
 open class AffectedTestConfiguration {
+    var testTasksProvider: Provider<TaskNames>? = null
 
-    var assembleAndroidTestTask: String? = DEFAULT_ASSEMBLE_ANDROID_TEST_TASK
-    var runAndroidTestTask: String? = DEFAULT_ANDROID_TEST_TASK
-    var jvmTestTask: String? = DEFAULT_JVM_TEST_TASK
+    fun getTestTaskNames(): TaskNames {
+        return testTasksProvider?.orNull ?: TaskNames()
+    }
 
-    var testTasksProvider: Provider<TasksNames>? = null
-
-    data class TasksNames(
-        val unitTestTasks: List<String>,
-        val androidTestTasks: List<String>,
-        val assembleAndroidTestTasks: List<String>,
+    data class TaskNames(
+        val unitTestTasks: List<String> = listOf(DEFAULT_JVM_TEST_TASK),
+        val androidTestTasks: List<String> = listOf(DEFAULT_ANDROID_TEST_TASK),
+        val assembleAndroidTestTasks: List<String> = listOf(DEFAULT_ASSEMBLE_ANDROID_TEST_TASK),
     ): Serializable
 
     companion object {

--- a/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedTestConfigurationTest.kt
+++ b/affectedmoduledetector/src/test/kotlin/com/dropbox/affectedmoduledetector/AffectedTestConfigurationTest.kt
@@ -15,27 +15,13 @@ class AffectedTestConfigurationTest {
 
     @Test
     fun `GIVEN AffectedTestConfiguration WHEN default values THEN default values returned`() {
-        assertThat(config.assembleAndroidTestTask).isEqualTo("assembleDebugAndroidTest")
-        assertThat(config.runAndroidTestTask).isEqualTo("connectedDebugAndroidTest")
-        assertThat(config.jvmTestTask).isEqualTo("testDebugUnitTest")
-    }
-
-    @Test
-    fun `GIVEN AffectedTestConfiguration WHEN values are updated THEN new values are returned`() {
-        // GIVEN
-        val assembleAndroidTestTask = "assembleAndroidTestTask"
-        val runAndroidTestTask = "runAndroidTestTask"
-        val jvmTest = "jvmTest"
-
-        // WHEN
-        config.assembleAndroidTestTask = assembleAndroidTestTask
-        config.runAndroidTestTask = runAndroidTestTask
-        config.jvmTestTask = jvmTest
-
-        // THEN
-        assertThat(config.assembleAndroidTestTask).isEqualTo(assembleAndroidTestTask)
-        assertThat(config.runAndroidTestTask).isEqualTo(runAndroidTestTask)
-        assertThat(config.jvmTestTask).isEqualTo(jvmTest)
+        val taskNames = config.getTestTaskNames()
+        assertThat(taskNames.assembleAndroidTestTasks.size).isEqualTo(1)
+        assertThat(taskNames.assembleAndroidTestTasks.first()).isEqualTo("assembleDebugAndroidTest")
+        assertThat(taskNames.androidTestTasks.size).isEqualTo(1)
+        assertThat(taskNames.androidTestTasks.first()).isEqualTo("connectedDebugAndroidTest")
+        assertThat(taskNames.unitTestTasks.size).isEqualTo(1)
+        assertThat(taskNames.unitTestTasks.first()).isEqualTo("testDebugUnitTest")
     }
 
     @Test


### PR DESCRIPTION
Added the ability to set multiple task names for multiple android variants.
Usage of Provider<> allows projects, that are using this plugin, to use AGP Variant API to provider task names

Breaking changes:
- old fields containing one task name in AffectedTestConfiguration were removed in favour of provider of lists 