### PR TITLE
Normalize Git-Relative paths to Project-Relative paths.

### DIFF
--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetector.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetector.kt
@@ -646,11 +646,9 @@ class AffectedModuleDetectorImpl(
     }
 
     private fun affectsAllModules(relativeFilePath: String): Boolean {
-        val rootProjectDir = if (config.baseDir != null) {
-            File(config.baseDir!!)
-        } else {
-            File(projectGraph.getRootProjectPath()!!.path)
-        }
+        val rootProjectDir = getRootProjectDir()
+
+        // Normalize the file path from git-relative to project-relative
         val pathSections = relativeFilePath.toPathSections(rootProjectDir, gitRoot)
         val projectRelativePath = pathSections.joinToString(File.separatorChar.toString())
 
@@ -658,17 +656,22 @@ class AffectedModuleDetectorImpl(
     }
 
     private fun findContainingProject(filePath: String): ProjectPath? {
+        val rootProjectDir = getRootProjectDir()
+
         // Normalize the file path from git-relative to project-relative
-        val rootProjectDir = if (config.baseDir != null) {
-            File(config.baseDir!!)
-        } else {
-            File(projectGraph.getRootProjectPath()!!.path)
-        }
         val pathSections = filePath.toPathSections(rootProjectDir, gitRoot)
         val projectRelativePath = pathSections.joinToString(File.separatorChar.toString())
 
         return projectGraph.findContainingProject(projectRelativePath, logger).also {
             logger?.info("search result for $filePath (normalized to $projectRelativePath) resulted in ${it?.path}")
+        }
+    }
+    
+    private fun getRootProjectDir(): File {
+        return if (config.baseDir != null) {
+            File(config.baseDir!!)
+        } else {
+            File(projectGraph.getRootProjectPath()!!.path)
         }
     }
 }

--- a/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetector.kt
+++ b/affectedmoduledetector/src/main/kotlin/com/dropbox/affectedmoduledetector/AffectedModuleDetector.kt
@@ -658,8 +658,17 @@ class AffectedModuleDetectorImpl(
     }
 
     private fun findContainingProject(filePath: String): ProjectPath? {
-        return projectGraph.findContainingProject(filePath, logger).also {
-            logger?.info("search result for $filePath resulted in ${it?.path}")
+        // Normalize the file path from git-relative to project-relative
+        val rootProjectDir = if (config.baseDir != null) {
+            File(config.baseDir!!)
+        } else {
+            File(projectGraph.getRootProjectPath()!!.path)
+        }
+        val pathSections = filePath.toPathSections(rootProjectDir, gitRoot)
+        val projectRelativePath = pathSections.joinToString(File.separatorChar.toString())
+
+        return projectGraph.findContainingProject(projectRelativePath, logger).also {
+            logger?.info("search result for $filePath (normalized to $projectRelativePath) resulted in ${it?.path}")
         }
     }
 }


### PR DESCRIPTION
Addresses regression from https://github.com/dropbox/AffectedModuleDetector/pull/270. Makes paths resolve correctly in repositories, where root project dir and Git rood dir do not match. 

This fixes https://github.com/dropbox/AffectedModuleDetector/issues/292